### PR TITLE
added consumption notification feature

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
             "LicenseManagerForWooCommerce\\Models\\Resources\\": "includes/models/resources",
             "LicenseManagerForWooCommerce\\Repositories\\": "includes/repositories",
             "LicenseManagerForWooCommerce\\Repositories\\Resources\\": "includes/repositories/resources",
+            "LicenseManagerForWooCommerce\\Schedules\\": "includes/schedules",
             "LicenseManagerForWooCommerce\\Settings\\": "includes/settings"
         }
     },

--- a/includes/Main.php
+++ b/includes/Main.php
@@ -16,6 +16,7 @@ use LicenseManagerForWooCommerce\Abstracts\Singleton;
 use LicenseManagerForWooCommerce\Controllers\ApiKey as ApiKeyController;
 use LicenseManagerForWooCommerce\Controllers\Generator as GeneratorController;
 use LicenseManagerForWooCommerce\Controllers\License as LicenseController;
+use LicenseManagerForWooCommerce\Schedules\NotifySchedule;
 use LicenseManagerForWooCommerce\Enums\LicenseStatus;
 
 defined('ABSPATH') || exit;
@@ -283,6 +284,7 @@ final class Main extends Singleton
         new LicenseController();
         new GeneratorController();
         new ApiKeyController();
+        new NotifySchedule();
         new API\Setup();
 
         if ($this->isPluginActive('woocommerce/woocommerce.php')) {

--- a/includes/integrations/woocommerce/Email.php
+++ b/includes/integrations/woocommerce/Email.php
@@ -2,6 +2,7 @@
 
 namespace LicenseManagerForWooCommerce\Integrations\WooCommerce;
 
+use LicenseManagerForWooCommerce\Integrations\WooCommerce\Emails\CustomerConsumptionNotification;
 use LicenseManagerForWooCommerce\Integrations\WooCommerce\Emails\CustomerDeliverLicenseKeys;
 use LicenseManagerForWooCommerce\Integrations\WooCommerce\Emails\CustomerPreorderComplete;
 use LicenseManagerForWooCommerce\Integrations\WooCommerce\Emails\Templates;
@@ -123,8 +124,9 @@ class Email
         new Templates();
 
         $pluginEmails = array(
-            //'LMFWC_Customer_Preorder_Complete'    => new CustomerPreorderComplete(),
-            'LMFWC_Customer_Deliver_License_Keys' => new CustomerDeliverLicenseKeys()
+            // 'LMFWC_Customer_Preorder_Complete'          => new CustomerPreorderComplete(),
+            'LMFWC_Customer_Deliver_License_Keys'       => new CustomerDeliverLicenseKeys(),
+            'LMFWC_Customer_Consumption_Notification'   => new CustomerConsumptionNotification()
         );
 
         return array_merge($emails, $pluginEmails);

--- a/includes/integrations/woocommerce/emails/CustomerConsumptionNotification.php
+++ b/includes/integrations/woocommerce/emails/CustomerConsumptionNotification.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace LicenseManagerForWooCommerce\Integrations\WooCommerce\Emails;
+
+use WC_Email;
+use WP_User;
+
+defined('ABSPATH') || exit;
+
+class CustomerConsumptionNotification extends WC_Email
+{
+    /**
+     * CustomerConsumptionNotification constructor.
+     */
+    function __construct()
+    {
+        // Email slug we can use to filter other data.
+        $this->id          = 'lmfwc_email_customer_consumption_notification';
+        $this->title       = __('License Key consumption notification', 'license-manager-for-woocommerce');
+        $this->description = __('An automatic email that is send out to the user, when a consumption threshold is reached.', 'license-manager-for-woocommerce');
+
+        // For admin area to let the user know we are sending this email to customers.
+        $this->customer_email = true;
+        $this->heading        = __('Notification', 'license-manager-for-woocommerce');
+
+        // translators: placeholder is {blogname}, a variable that will be substituted when email is sent out
+        $this->subject = sprintf(
+            _x(
+                '[%s] - License key notification!',
+                'Default email subject for resent consumption notification sent to the customer',
+                'license-manager-for-woocommerce'
+            ),
+            '{blogname}'
+        );
+
+        // Template paths.
+        $this->template_html  = 'emails/lmfwc-email-consumption-notification.php';
+        $this->template_plain = 'emails/plain/lmfwc-email-consumption-notification.php';
+        $this->template_base  = LMFWC_TEMPLATES_DIR;
+
+        // Action to which we hook onto to send the email.
+        add_action('lmfwc_email_customer_consumption_notification', array($this, 'trigger'));
+
+        parent::__construct();
+    }
+
+    /**
+     * Retrieves the HTML content of the email.
+     *
+     * @return string
+     */
+    public function get_content_html()
+    {
+        return wc_get_template_html(
+            $this->template_html,
+            array(
+                'user'          => $this->object,
+                'license_count' => $this->placeholders['{license_count}'],
+                'threshold'     => $this->placeholders['{threshold}'],
+                'email_heading' => $this->get_heading(),
+                'sent_to_admin' => false,
+                'plain_text'    => false,
+                'email'         => $this
+            ),
+            '',
+            $this->template_base
+        );
+    }
+
+    /**
+     * Retrieves the plain text content of the email.
+     *
+     * @return string
+     */
+    public function get_content_plain()
+    {
+        return wc_get_template_html(
+            $this->template_plain,
+            array(
+                'user'          => $this->object,
+                'license_count' => $this->placeholders['{license_count}'],
+                'threshold'     => $this->placeholders['{threshold}'],
+                'email_heading' => $this->get_heading(),
+                'sent_to_admin' => false,
+                'plain_text'    => true,
+                'email'         => $this
+            ),
+            '',
+            $this->template_base
+        );
+    }
+
+    /**
+     * Trigger the sending of the consumption data.
+     *
+     * @param WP_User $user         the email of the user associated with the license
+     * @param int     $count        the sum of licenses that have reached the consumption threshold
+     * @param int     $threshold    the threshold
+     */
+    public function trigger($user, $threshold, $count)
+    {
+        $this->setup_locale();
+
+        $ok = false;
+        $sent = false;
+
+        if (is_a($user, 'WP_User') && $count && $threshold) {
+            $this->object                           = $user;
+            $this->recipient                        = $user->user_email;
+            $this->placeholders['{license_count}']  = $count;
+            $this->placeholders['{threshold}']      = $threshold;
+
+            $ok = true;
+        }
+
+        if ($this->is_enabled() && $this->get_recipient()) {
+            $sent = $this->send(
+                $this->get_recipient(),
+                $this->get_subject(),
+                $this->get_content(),
+                $this->get_headers(),
+                $this->get_attachments()
+            );
+        }
+
+        $this->restore_locale();
+
+        return $ok && $sent;
+    }
+}

--- a/includes/integrations/woocommerce/emails/Templates.php
+++ b/includes/integrations/woocommerce/emails/Templates.php
@@ -14,8 +14,9 @@ class Templates
      */
     function __construct()
     {
-        add_action('lmfwc_email_order_details',      array($this, 'addOrderDetails'),     10, 4);
-        add_action('lmfwc_email_order_license_keys', array($this, 'addOrderLicenseKeys'), 10, 4);
+        add_action('lmfwc_email_order_details',        array($this, 'addOrderDetails'),         10, 4);
+        add_action('lmfwc_email_order_license_keys',   array($this, 'addOrderLicenseKeys'),     10, 4);
+        add_action('lmfwc_email_consumption_details',  array($this, 'addConsumptionDetails'),   10, 6);
     }
 
     /**
@@ -97,6 +98,53 @@ class Templates
                     'data'          => apply_filters('lmfwc_get_customer_license_keys', $order),
                     'date_format'   => get_option('date_format'),
                     'order'         => $order,
+                    'sent_to_admin' => false,
+                    'plain_text'    => false,
+                    'email'         => $email,
+                    'args'          => apply_filters('lmfwc_template_args_emails_order_license_keys', array())
+                ),
+                '',
+                LMFWC_TEMPLATES_DIR
+            );
+        }
+    }
+
+    /**
+     * Adds consumption info to the email body.
+     *
+     * @param WP_User  $user            WordPress User
+     * @param int      $licenseCount    Number of licenses that are over the threshold
+     * @param int      $threshold       The threshold
+     * @param bool     $sentToAdmin     Determines if the email is sent to the admin
+     * @param bool     $plainText       Determines if a plain text or HTML email will be sent
+     * @param WC_Email $email           WooCommerce Email
+     */
+    public function addConsumptionDetails($user, $licenseCount, $threshold, $sentToAdmin, $plainText, $email)
+    {
+        if ($plainText) {
+            echo wc_get_template(
+                'emails/plain/lmfwc-email-consumption-details.php',
+                array(
+                    'user'          => $user,
+                    'license_count' => $licenseCount,
+                    'threshold'     => $threshold,
+                    'sent_to_admin' => false,
+                    'plain_text'    => false,
+                    'email'         => $email,
+                    'args'          => apply_filters('lmfwc_template_args_emails_order_license_keys', array())
+                ),
+                '',
+                LMFWC_TEMPLATES_DIR
+            );
+        }
+
+        else {
+            echo wc_get_template_html(
+                'emails/lmfwc-email-consumption-details.php',
+                array(
+                    'user'          => $user,
+                    'license_count' => $licenseCount,
+                    'threshold'     => $threshold,
                     'sent_to_admin' => false,
                     'plain_text'    => false,
                     'email'         => $email,

--- a/includes/schedules/NotifySchedule.php
+++ b/includes/schedules/NotifySchedule.php
@@ -1,0 +1,155 @@
+<?php
+
+namespace LicenseManagerForWooCommerce\Schedules;
+
+use DateTime;
+use Exception;
+use LicenseManagerForWooCommerce\Settings;
+use LicenseManagerForWooCommerce\Enums\LicenseStatus as LicenseStatusEnum;
+use LicenseManagerForWooCommerce\Models\Resources\License as LicenseResourceModel;
+use LicenseManagerForWooCommerce\Repositories\Resources\License as LicenseResourceRepository;
+use LicenseManagerForWooCommerce\Models\Resources\LicenseMeta as LicenseMetaResourceModel;
+use LicenseManagerForWooCommerce\Repositories\Resources\LicenseMeta as LicenseMetaResourceRepository;
+use WP_User;
+
+use WC_Order;
+
+defined('ABSPATH') || exit;
+
+class NotifySchedule
+{
+    /**
+     * Name of the hook that should be scheduled
+     */
+    const HOOK_NAME = 'lmfwc_consumption_almost_reached_action';
+
+    /**
+     * The start time of the scheduled event
+     */
+    const START_TIME = 'now';
+
+    /**
+     * The recurrence of the event
+     */
+    const RECURRENCE = 'daily';
+
+    /**
+     * NotifySchedule constructor.
+     */
+    public function __construct()
+    {
+        // email schedule action
+        add_action(self::HOOK_NAME, array($this, 'maybeNotifyConsumptionAlmostReached'), 10);
+
+        $notifyThreshold = Settings::get('lmfwc_email_notification_consumption');
+        ($notifyThreshold !== null && !empty($notifyThreshold)) ? $this->schedule() : $this->remove();
+    }
+
+    /**
+     * Sends out consumption notifications if required.
+     */
+    public function maybeNotifyConsumptionAlmostReached()
+    {
+
+        $notifyThreshold = Settings::get('lmfwc_email_notification_consumption');
+        $metaKey = 'consumption_notification_already_send';
+
+        /** @var bool|LicenseResourceModel[] $licenses */
+        $licenses = lmfwc_get_licenses(array(
+            'status' => array(LicenseStatusEnum::DELIVERED, LicenseStatusEnum::ACTIVE)
+        ));
+
+        if (!$licenses) {
+            return;
+        }
+
+        $licenseCount = count($licenses);
+        $notificationSummary = array();
+
+        /** @var LicenseResourceModel $license */
+        foreach ($licenses as $license) {
+
+            // Skip license that has expired
+            try {
+                $dateExpiresAt = new DateTime($license->getExpiresAt());
+
+                $interval = $dateExpiresAt->diff(new DateTime())->format('%r%a');
+                if (intval($interval) > 0) {
+                    continue;
+                }
+            } catch (Exception $e) {
+                continue;
+            }
+
+            // Skip license if there is no activation limit
+            $timesActivatedMax = $license->getTimesActivatedMax();
+            if (!$timesActivatedMax || $timesActivatedMax === 0) {
+                continue;
+            }
+
+            // Skip license if it has not reached the required consumption threshold
+            $timesActivated = $license->getTimesActivated();
+            if (($timesActivated / $timesActivatedMax * 100) < $notifyThreshold) {
+                continue;
+            }
+
+            // Skip if notification was already send
+            $licenseId = $license->getId();
+
+            /** @var bool $metaValue */
+            $metaValue = boolval(lmfwc_get_license_meta($licenseId, $metaKey, true));
+            if ($metaValue) {
+                continue;
+            }
+
+            $userId = $license->getUserId();
+
+            // license does not have a user assigned
+            if (!$userId) {
+                continue;
+            }
+
+            $notificationSummary[$userId][] = $licenseId;
+        }
+
+        /** @var int $user */
+        /** @var int[] $ids */
+        foreach ($notificationSummary as $userId => $ids) {
+
+            $licenseCount = count($ids);
+
+            /** @var WP_User $user */
+            $user = get_user_by('id', $userId);
+
+            // The given user does not exist
+            if (!$user) {
+                continue;
+            }
+
+            // send e-mail
+            $sent = WC()->mailer()->emails['LMFWC_Customer_Consumption_Notification']->trigger($user, $notifyThreshold, $licenseCount);
+
+            if ($sent) {
+                foreach ($ids as $id) {
+                    // update or add meta value
+                    if (!lmfwc_update_license_meta($id, $metaKey, intval(true))) {
+                        lmfwc_add_license_meta($id, $metaKey, intval(true));
+                    }
+                }
+            }
+        }
+    }
+
+    private function schedule($args = array())
+    {
+        if (!wp_next_scheduled(self::HOOK_NAME))
+            wp_schedule_event(strtotime(self::START_TIME), self::RECURRENCE, self::HOOK_NAME, $args);
+    }
+
+    private function remove($args = array())
+    {
+        if (wp_next_scheduled(self::HOOK_NAME))
+            wp_clear_scheduled_hook(self::HOOK_NAME, $args);
+    }
+
+}

--- a/includes/settings/General.php
+++ b/includes/settings/General.php
@@ -119,6 +119,14 @@ class General
             'lmfwc_license_keys',
             'license_keys_section'
         );
+
+        add_settings_field(
+            'lmfwc_email_notification_consumption',
+            __('Email notification', 'license-manager-for-woocommerce'),
+            array($this, 'fieldEmailNotificationConsumption'),
+            'lmfwc_license_keys',
+            'license_keys_section'
+        );
     }
 
     /**
@@ -325,6 +333,43 @@ class General
                 </p>
             </fieldset>
         ';
+
+        echo $html;
+    }
+
+    /**
+     * Callback for the "lmfwc_email_notification_consumption" field.
+     *
+     * @return void
+     */
+    public function fieldEmailNotificationConsumption()
+    {
+        $field = 'lmfwc_email_notification_consumption';
+        (array_key_exists($field, $this->settings)) ? $value = $this->settings[$field] : $value = '';
+
+        $min = 50;
+        $max = 99;
+
+        $html = '<fieldset>';
+        $html .= sprintf('<label for="%s">', $field);
+        $html .= sprintf(
+            '<input id="%s" type="number" min="%d" max="%d" name="lmfwc_settings_general[%s]" value="%s" />',
+            $field,
+            $min,
+            $max,
+            $field,
+            $value
+        );
+        $html .= sprintf(
+            '<span>%s</span>',
+            __(' %', 'license-manager-for-woocommerce')
+        );
+        $html .= '</label>';
+        $html .= sprintf(
+            '<p class="description">%s</p>',
+            __('Notify customer when the given percentage of activations is reached. Remove value to disable notifications.', 'license-manager-for-woocommerce')
+        );
+        $html .= '</fieldset>';
 
         echo $html;
     }

--- a/templates/emails/lmfwc-email-consumption-details.php
+++ b/templates/emails/lmfwc-email-consumption-details.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * The template which warns the user that the consumption threshold has been reached (HTML).
+ *
+ * This template can be overridden by copying it to yourtheme/woocommerce/emails/lmfwc-email-consumption-details.php.
+ *
+ * HOWEVER, on occasion I will need to update template files and you
+ * (the developer) will need to copy the new files to your theme to
+ * maintain compatibility. I try to do this as little as possible, but it does
+ * happen. When this occurs the version of the template file will be bumped and
+ * the readme will list any important changes.
+ *
+ * @version 1.0.0
+ */
+
+use LicenseManagerForWooCommerce\Models\Resources\License;
+
+defined('ABSPATH') || exit; ?>
+
+<div style="margin-bottom: 40px;">
+    <?php $name = $user->user_firstname ? $user->user_firstname : $user->display_name; ?>
+    <p><?php printf(esc_html__('Hi %s,', 'license-manager-for-woocommerce'), $name); ?></p>
+    <p><?php printf(esc_html__('You have now reached %d percent consumption on %d license key(s). Consider upgrading your license key or buy a new one.', 'license-manager-for-woocommerce'), $threshold, $license_count); ?></p>
+    <p><?php esc_html_e('Best regards,', 'license-manager-for-woocommerce'); ?></p>
+</div>

--- a/templates/emails/lmfwc-email-consumption-notification.php
+++ b/templates/emails/lmfwc-email-consumption-notification.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Deliver Order license key(s) to Customer.
+ */
+defined('ABSPATH') || exit;
+
+/**
+ * @hooked WC_Emails::email_header() Output the email header
+ */
+do_action('woocommerce_email_header', $email_heading, $email);
+
+/**
+ * @hooked \LicenseManagerForWooCommerce\Emails\Main Output consumption details.
+ */
+do_action('lmfwc_email_consumption_details', $user, $license_count, $threshold, $sent_to_admin, $plain_text, $email);
+
+/**
+ * @hooked WC_Emails::email_footer() Output the email footer
+ */
+do_action('woocommerce_email_footer', $email);

--- a/templates/emails/plain/lmfwc-email-consumption-details.php
+++ b/templates/emails/plain/lmfwc-email-consumption-details.php
@@ -1,0 +1,3 @@
+<?php
+
+defined('ABSPATH') || exit;

--- a/templates/emails/plain/lmfwc-email-consumption-notification.php
+++ b/templates/emails/plain/lmfwc-email-consumption-notification.php
@@ -1,0 +1,3 @@
+<?php
+
+defined('ABSPATH') || exit;


### PR DESCRIPTION
Hi Drazan,

with this change a new option has been added to the general settings. This allows to choose a percentage (limited from 50 to 99) of when a user should be notified that the times activated has reached a critical number. The setting of the option starts a daily schedule that checks each active and not expired license with a set maximum activations, if the given consumption threshold has been reached and notifies the owner. The scheduled hook makes use of the license_meta table to track if a user has already been notified, so that the user is not spammed.

The feature has been tested and it runs fine.