### PR TITLE
timesActivatedMax is now set to null instead of 0 when generating a new license

### DIFF
--- a/includes/integrations/woocommerce/Controller.php
+++ b/includes/integrations/woocommerce/Controller.php
@@ -226,7 +226,7 @@ class Controller extends AbstractIntegrationController implements IntegrationCon
                     'valid_for'           => $generator->getExpiresIn(),
                     'source'              => LicenseSource::GENERATOR,
                     'status'              => $cleanStatus,
-                    'times_activated_max' => $generator->getTimesActivatedMax()
+                    'times_activated_max' => $generator->getTimesActivatedMax() ?: null
                 )
             );
         }


### PR DESCRIPTION
A fix to solve an visual issue on the license keys page (admin panel). When the license key does not have any activations the condition "$timesActivated == $timesActivatedMax" is met therefore showing the the checkmark in the activations column (class="dashicons dashicons-yes")