### PR TITLE
Feature/license status disabled

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -197,6 +197,14 @@ table.wp-list-table.lizenzschlssel span.lmfwc-date {
 	color: var(--color-danger);
 }
 
+.lmfwc-status.disabled {
+	border: 2px solid var(--color-warning);
+	color: var(--color-warning);
+}
+.lmfwc-status.disabled > span.dashicons {
+	color: var(--color-warning);
+}
+
 .lmfwc-status.activation.done,
 .lmfwc-status.activation.done > span.dashicons {
 	color: var(--color-info);

--- a/functions/lmfwc-license-functions.php
+++ b/functions/lmfwc-license-functions.php
@@ -363,6 +363,10 @@ function lmfwc_activate_license($licenseKey)
         $timesActivatedMax = absint($license->getTimesActivatedMax());
     }
 
+    if ($license->getStatus() === LicenseStatusEnum::DISABLED) {
+        throw new Exception("License Key: {$licenseKey} is disabled.");
+    }
+
     if ($timesActivatedMax && ($timesActivated >= $timesActivatedMax)) {
         throw new Exception("License Key: {$licenseKey} reached maximum activation count.");
     }
@@ -412,6 +416,10 @@ function lmfwc_deactivate_license($licenseKey)
 
     if ($license->getTimesActivated() !== null) {
         $timesActivated = absint($license->getTimesActivated());
+    }
+
+    if ($license->getStatus() === LicenseStatusEnum::DISABLED) {
+        throw new Exception("License Key: {$licenseKey} is disabled.");
     }
 
     if (!$timesActivated || $timesActivated === 0) {

--- a/includes/abstracts/RestController.php
+++ b/includes/abstracts/RestController.php
@@ -107,6 +107,10 @@ class RestController extends WP_REST_Controller
             return LicenseStatus::INACTIVE;
         }
 
+        if (strtoupper($enumerator) === 'DISABLED') {
+            return LicenseStatus::DISABLED;
+        }
+
         return $status;
     }
 

--- a/includes/api/v2/Licenses.php
+++ b/includes/api/v2/Licenses.php
@@ -634,8 +634,8 @@ class Licenses extends LMFWC_REST_Controller
             return $licenseExpired;
         }
 
-        if (false !== $licenseExpired = $this->isLicenseDisabled($license)) {
-            return $licenseExpired;
+        if (false !== $licenseDisabled = $this->isLicenseDisabled($license)) {
+            return $licenseDisabled;
         }
 
         $timesActivated    = null;
@@ -757,8 +757,8 @@ class Licenses extends LMFWC_REST_Controller
             return $licenseExpired;
         }
 
-        if (false !== $licenseExpired = $this->isLicenseDisabled($license)) {
-            return $licenseExpired;
+        if (false !== $licenseDisabled = $this->isLicenseDisabled($license)) {
+            return $licenseDisabled;
         }
 
         $timesActivated = null;
@@ -928,6 +928,7 @@ class Licenses extends LMFWC_REST_Controller
                 array('status' => 405)
             );
         }
+        
         return false;
     }
 }

--- a/includes/api/v2/Licenses.php
+++ b/includes/api/v2/Licenses.php
@@ -634,6 +634,10 @@ class Licenses extends LMFWC_REST_Controller
             return $licenseExpired;
         }
 
+        if (false !== $licenseExpired = $this->isLicenseDisabled($license)) {
+            return $licenseExpired;
+        }
+
         $timesActivated    = null;
         $timesActivatedMax = null;
 
@@ -750,6 +754,10 @@ class Licenses extends LMFWC_REST_Controller
         }
 
         if (false !== $licenseExpired = $this->hasLicenseExpired($license)) {
+            return $licenseExpired;
+        }
+
+        if (false !== $licenseExpired = $this->isLicenseDisabled($license)) {
             return $licenseExpired;
         }
 
@@ -902,6 +910,24 @@ class Licenses extends LMFWC_REST_Controller
             }
         }
 
+        return false;
+    }
+
+    /**
+     * Checks if the license is disabled.
+     *
+     * @param LicenseResourceModel $license
+     * @return false|WP_Error
+     */
+    private function isLicenseDisabled($license)
+    {
+        if ($license->getStatus() === LicenseStatus::DISABLED) {
+            return new WP_Error(
+                'lmfwc_rest_license_disabled',
+                'The license Key is disabled.',
+                array('status' => 405)
+            );
+        }
         return false;
     }
 }

--- a/includes/enums/LicenseStatus.php
+++ b/includes/enums/LicenseStatus.php
@@ -38,6 +38,13 @@ abstract class LicenseStatus
     const INACTIVE = 4;
 
     /**
+     * Enumerator value used for disabled licenses.
+     *
+     * @var int
+     */
+    const DISABLED = 5;
+
+    /**
      * Available enumerator values.
      *
      * @var array
@@ -46,7 +53,8 @@ abstract class LicenseStatus
         self::SOLD,
         self::DELIVERED,
         self::ACTIVE,
-        self::INACTIVE
+        self::INACTIVE,
+        self::DISABLED
     );
 
     /**
@@ -58,7 +66,8 @@ abstract class LicenseStatus
         'sold',
         'delivered',
         'active',
-        'inactive'
+        'inactive',
+        'disabled'
     );
 
     /**
@@ -70,7 +79,8 @@ abstract class LicenseStatus
         'sold'      => self::SOLD,
         'delivered' => self::DELIVERED,
         'active'    => self::ACTIVE,
-        'inactive'  => self::INACTIVE
+        'inactive'  => self::INACTIVE,
+        'disabled'  => self::DISABLED
     );
 
     /**
@@ -86,7 +96,8 @@ abstract class LicenseStatus
             self::SOLD      => 'SOLD',
             self::DELIVERED => 'DELIVERED',
             self::ACTIVE    => 'ACTIVE',
-            self::INACTIVE  => 'INACTIVE'
+            self::INACTIVE  => 'INACTIVE',
+            self::DISABLED  => 'DISABLED'
         );
 
         return $labels[$status];
@@ -115,6 +126,10 @@ abstract class LicenseStatus
             array(
                 'value' => self::DELIVERED,
                 'name' => __('Delivered', 'license-manager-for-woocommerce')
+            ),
+            array(
+                'value' => self::DISABLED,
+                'name' => __('Disabled', 'license-manager-for-woocommerce')
             )
         );
     }

--- a/includes/integrations/woocommerce-subscriptions/Controller.php
+++ b/includes/integrations/woocommerce-subscriptions/Controller.php
@@ -34,6 +34,7 @@ class Controller extends AbstractIntegrationController implements IntegrationCon
         new Lists\LicensesList();
         new Order();
         new ProductData();
+        new Suspend();
     }
 
     /**

--- a/includes/integrations/woocommerce-subscriptions/Suspend.php
+++ b/includes/integrations/woocommerce-subscriptions/Suspend.php
@@ -1,0 +1,135 @@
+<?php
+
+
+namespace LicenseManagerForWooCommerce\Integrations\WooCommerceSubscriptions;
+
+use DateTime;
+use Exception;
+use DateTimeZone;
+use WC_Subscription;
+use LicenseManagerForWooCommerce\Settings;
+use LicenseManagerForWooCommerce\Enums\LicenseStatus as LicenseStatusEnum;
+use LicenseManagerForWooCommerce\Models\Resources\License as LicenseResourceModel;
+
+defined('ABSPATH') || exit;
+
+class Suspend
+{
+
+    /**
+     * @var string
+     */
+    private const STATUS_META_KEY = 'previous_subscription_status_for_%s';
+
+    /**
+     * Suspend constructor.
+     */
+    public function __construct()
+    {
+        add_action('woocommerce_subscription_status_updated', array($this, 'updateRelatedLicenses'), 90, 3);
+    }
+
+    /**
+     * Finds all the related license(s) to the WooCommerce Subscription and sets
+     * the status to the given new status.
+     * 
+     * It will be triggered for all status changes defined by WooCommerce Subscriptions, 
+     * including: pending, active, on-hold, pending-cancel, cancelled, or expired; 
+     * as well as any custom subscription statuses.
+     *
+     * @param int $subscription   Subscription that has been put on hold
+     * @param string $newWCSubStatus   The string representation of the new status applied to the subscription.
+     * @param string $oldWCSubStatus   The string representation of the subscriptions status before the change was applied.
+     * @return bool
+     */
+    public function updateRelatedLicenses($subscription, $newWCSubStatus, $oldWCSubStatus)
+    {
+        if ($newWCSubStatus === 'cancelled' || $newWCSubStatus === 'on-hold') {
+            $newLicenseStatus = LicenseStatusEnum::DISABLED;
+        } else if ($newWCSubStatus === 'active' && $oldWCSubStatus === 'on-hold') {
+            $newLicenseStatus = Settings::get('lmfwc_auto_delivery') ? LicenseStatusEnum::DELIVERED : LicenseStatusEnum::SOLD;
+        } else {
+            error_log("LMFWC: Skipped because status change is not relevant. ");
+            return false;
+        }
+
+        /** @var int[] $parentOrderArray */
+        $parentOrderArray = $subscription->get_related_orders('ids', 'any');
+
+        if (!$parentOrderArray || count($parentOrderArray) === 0) {
+            error_log("LMFWC: Skipped because the parent orders could not be found. ");
+            return false;
+        }
+
+        /** @var int $parentOrderId */
+        foreach ($parentOrderArray as $parentOrderId) {
+
+            /** @var false|LicenseResourceModel[] $licenses */
+            $licenses = lmfwc_get_licenses(
+                array(
+                    'order_id' => $parentOrderId
+                )
+            );
+
+            if (!$licenses) {
+                error_log("LMFWC: Skipped parent Order #{$parentOrderId} because no licenses were found.");
+                continue;
+            }
+
+            $licenseCount = count($licenses);
+            error_log("LMFWC: License count is: {$licenseCount}");
+
+            /** @var LicenseResourceModel $license */
+            foreach ($licenses as $license) {
+
+                $expiresAt = $license->getExpiresAt();
+                if ($expiresAt && $expiresAt !== '') {
+                    try {
+                        $dateExpiresAt = new DateTime($license->getExpiresAt());
+                    } catch (Exception $e) {
+                        continue;
+                    }
+    
+                    $interval = $dateExpiresAt->diff(new DateTime('now', new DateTimeZone('UTC')))->format('%r%a');
+                    if (intval($interval) > 0) {
+                        error_log("LMFWC: Skipped because license has already expired $interval day(s) ago.");
+                        continue;
+                    }
+                }
+
+                $previousStatus = lmfwc_get_license_meta($license->getId(), sprintf(self::STATUS_META_KEY, $oldWCSubStatus), true);
+                if ($previousStatus && in_array($previousStatus, LicenseStatusEnum::$values)) {
+                    $newLicenseStatus = $previousStatus;
+                }
+
+                $currentLicenseStatus = $license->getStatus();
+                if ($newWCSubStatus !== 'active') {
+                    $metaKey = sprintf(self::STATUS_META_KEY, $newWCSubStatus);
+                    if (!lmfwc_update_license_meta($license->getId(), $metaKey, $currentLicenseStatus)) {
+                        lmfwc_add_license_meta($license->getId(), $metaKey, $currentLicenseStatus);
+                    }
+                }
+
+                error_log("LMFWC: previous status: {$previousStatus}");
+                error_log("LMFWC: Status current: {$currentLicenseStatus}");
+                error_log("LMFWC: Status NEW: {$newLicenseStatus}");
+
+                try {
+                    lmfwc_update_license(
+                        $license->getDecryptedLicenseKey(),
+                        array(
+                            'status' => intval($newLicenseStatus)
+                        )
+                    );
+                } catch (Exception $e) {
+                    continue;
+                }
+            }
+        }
+
+        error_log("LMFWC: Success, returning TRUE");
+
+        return true;
+    }
+
+}

--- a/includes/lists/LicensesList.php
+++ b/includes/lists/LicensesList.php
@@ -134,6 +134,17 @@ class LicensesList extends WP_List_Table
             LicenseResourceRepository::instance()->countBy(array('status' => LicenseStatus::INACTIVE))
         );
 
+        // Disabled link
+        $class = $current == LicenseStatus::DISABLED ? ' class="current"' :'';
+        $disabledUrl = esc_url(add_query_arg('status', LicenseStatus::DISABLED));
+        $statusLinks['disabled'] = sprintf(
+            '<a href="%s" %s>%s <span class="count">(%d)</span></a>',
+            $disabledUrl,
+            $class,
+            __('Disabled', 'license-manager-for-woocommerce'),
+            LicenseResourceRepository::instance()->countBy(array('status' => LicenseStatus::DISABLED))
+        );
+
         return $statusLinks;
     }
 
@@ -400,6 +411,7 @@ class LicensesList extends WP_List_Table
         // Activate, Deactivate
         if ($item['status'] != LicenseStatus::SOLD
             && $item['status'] != LicenseStatus::DELIVERED
+            && $item['status'] != LicenseStatus::DISABLED
         ) {
             if ($item['status'] != LicenseStatus::ACTIVE) {
                 $actions['activate'] = sprintf(
@@ -804,6 +816,12 @@ class LicensesList extends WP_List_Table
                     __('Inactive', 'license-manager-for-woocommerce')
                 );
                 break;
+            case LicenseStatus::DISABLED:
+                $status = sprintf(
+                    '<div class="lmfwc-status disabled"><span class="dashicons dashicons-warning"></span> %s</div>',
+                    __('Disabled', 'license-manager-for-woocommerce')
+                );
+                break;
             default:
                 $status = sprintf(
                     '<div class="lmfwc-status unknown">%s</div>',
@@ -864,6 +882,7 @@ class LicensesList extends WP_List_Table
             'deactivate'        => __('Deactivate', 'license-manager-for-woocommerce'),
             'mark_as_sold'      => __('Mark as sold', 'license-manager-for-woocommerce'),
             'mark_as_delivered' => __('Mark as delivered', 'license-manager-for-woocommerce'),
+            'mark_as_disabled'  => __('Mark as disabled', 'license-manager-for-woocommerce'),
             'delete'            => __('Delete', 'license-manager-for-woocommerce'),
             'export_csv'        => __('Export (CSV)', 'license-manager-for-woocommerce'),
             'export_pdf'        => __('Export (PDF)', 'license-manager-for-woocommerce')
@@ -891,6 +910,9 @@ class LicensesList extends WP_List_Table
                 break;
             case 'mark_as_delivered':
                 $this->toggleLicenseKeyStatus(LicenseStatus::DELIVERED);
+                break;
+            case 'mark_as_disabled':
+                $this->toggleLicenseKeyStatus(LicenseStatus::DISABLED);
                 break;
             case 'delete':
                 $this->deleteLicenseKeys();
@@ -1098,6 +1120,9 @@ class LicensesList extends WP_List_Table
                 break;
             case LicenseStatus::ACTIVE:
                 $nonce = 'activate';
+                break;
+            case LicenseStatus::DISABLED:
+                $nonce = 'disable';
                 break;
             default:
                 $nonce = 'deactivate';

--- a/includes/lists/LicensesList.php
+++ b/includes/lists/LicensesList.php
@@ -880,9 +880,9 @@ class LicensesList extends WP_List_Table
         $actions = array(
             'activate'          => __('Activate', 'license-manager-for-woocommerce'),
             'deactivate'        => __('Deactivate', 'license-manager-for-woocommerce'),
+            'disable'           => __('Mark as disabled', 'license-manager-for-woocommerce'),
             'mark_as_sold'      => __('Mark as sold', 'license-manager-for-woocommerce'),
             'mark_as_delivered' => __('Mark as delivered', 'license-manager-for-woocommerce'),
-            'mark_as_disabled'  => __('Mark as disabled', 'license-manager-for-woocommerce'),
             'delete'            => __('Delete', 'license-manager-for-woocommerce'),
             'export_csv'        => __('Export (CSV)', 'license-manager-for-woocommerce'),
             'export_pdf'        => __('Export (PDF)', 'license-manager-for-woocommerce')
@@ -905,14 +905,14 @@ class LicensesList extends WP_List_Table
             case 'deactivate':
                 $this->toggleLicenseKeyStatus(LicenseStatus::INACTIVE);
                 break;
+            case 'disable':
+                $this->toggleLicenseKeyStatus(LicenseStatus::DISABLED);
+                break;
             case 'mark_as_sold':
                 $this->toggleLicenseKeyStatus(LicenseStatus::SOLD);
                 break;
             case 'mark_as_delivered':
                 $this->toggleLicenseKeyStatus(LicenseStatus::DELIVERED);
-                break;
-            case 'mark_as_disabled':
-                $this->toggleLicenseKeyStatus(LicenseStatus::DISABLED);
                 break;
             case 'delete':
                 $this->deleteLicenseKeys();


### PR DESCRIPTION
Hi @drazenbebic 

a new 'disabled' status has been added to the LicenseStatusEnum class. The new status is used for denying activation/deactivation over the API and over the MyAccount license page and can be set over the license list page (admin) from bulk actions. This is beneficial for subscriptions that have been set on-hold or have been cancelled. The status of the license will change automatically if the subscription will be put on-hold or get cancelled. The license status will return to its pevious state, when the subscription is reactivated. The subscription status change can be changed manually or can change if e.g. the renewal order failed. This partly solves or attempts to solve #59 