### PR TITLE
Introducing the new product management & order downloads expiration feature 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ vendor
 vendor/*
 .idea
 .idea/*
+/composer.phar

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -135,10 +135,10 @@ table.wp-list-table.lizenzschlssel span.lmfwc-date {
 	border-radius: 3px;
 	opacity: 1;
 	-webkit-box-shadow: 2px 3px 5px rgba(0,0,0,.1);
-			box-shadow: 2px 3px 5px rgba(0,0,0,.1);
+	box-shadow: 2px 3px 5px rgba(0,0,0,.1);
 	-webkit-transition: all .5s ease-out;
-		 -o-transition: all .5s ease-out;
-			transition: all .5s ease-out;
+	-o-transition: all .5s ease-out;
+	transition: all .5s ease-out;
 }
 
 /* Source Icons */
@@ -215,7 +215,7 @@ table.wp-list-table.lizenzschlssel span.lmfwc-date {
 	display: inline-block;
 }
 .lmfwc-icons:before {
-	font-family: woocommerce;
+	font-family: woocommerce, sans-serif;
 	text-align: center;
 	display: inline-block;
 	width: 100%;

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -242,3 +242,40 @@ table.wp-list-table.lizenzschlssel span.lmfwc-date {
 	background-color: var(--color-info);
 	color: #ffffff;
 }
+
+/** Products **/
+#license_manager_product_data .form-field.lmfwc_licensed_product_changelog {
+	padding: 5px 12px 5px 162px;
+	position: relative;
+	margin: 9px 0;
+}
+#license_manager_product_data .form-field.lmfwc_licensed_product_changelog label {
+	position: absolute;
+	left: 0;
+	margin: 0 12px;
+	line-height: 24px;
+	font-size: 12px;
+}
+#license_manager_product_data .form-field.lmfwc_licensed_product_changelog #wp-lmfwc_licensed_product_changelog-wrap {
+	margin-top: 23px;
+}
+.button.lmfwc-license-keys-show-all {
+	margin-right: 5px;
+}
+
+@media only screen and (max-width: 500px) {
+	#license_manager_product_data .form-field.lmfwc_licensed_product_changelog {
+		padding: 5px 20px;
+	}
+}
+
+@media only screen and (max-width: 1280px) {
+	#license_manager_product_data .form-field.lmfwc_licensed_product_changelog {
+		padding: 5px 12px 5px 12px;
+		clear: both;
+	}
+	#license_manager_product_data .form-field.lmfwc_licensed_product_changelog label {
+		position: static;
+		margin: 0;
+	}
+}

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -1,204 +1,217 @@
-document.addEventListener('DOMContentLoaded', function(event) {
+(function ( $ ) {
+    $( document ).ready( function () {
+        const licenseKeysCheckbox = $( '#lmfwc_licensed_product' );
 
-    var licenseTable = {
-        btnHideLicense: document.querySelectorAll('.lmfwc-license-key-hide'),
-        btnShowLicense: document.querySelectorAll('.lmfwc-license-key-show'),
-        btnCopyToClipboard: document.querySelectorAll('code.lmfwc-placeholder'),
-        txtCopiedToClipboard: document.querySelector('.lmfwc-txt-copied-to-clipboard'),
-        bindEventListeners: function() {
-            let i;
-            const that = this;
+        registerClickHandlers( licenseKeysCheckbox );
+        registerChangeHandlers();
 
-            if (this.btnHideLicense) {
-                for (i = 0; i < this.btnHideLicense.length; i++) {
-                    this.btnHideLicense[i].addEventListener('click', function() {
-                        that.hideLicenseKey(this);
-                    });
-                }
-            }
-
-            if (this.btnShowLicense) {
-                for (i = 0; i < this.btnShowLicense.length; i++) {
-                    this.btnShowLicense[i].addEventListener('click', function() {
-                        that.showLicenseKey(this);
-                    });
-                }
-            }
-
-            if (this.btnCopyToClipboard) {
-                for (i = 0; i < this.btnCopyToClipboard.length; i++) {
-                    this.btnCopyToClipboard[i].addEventListener('click', function(e) {
-                        that.copyToClipboard(this, e);
-                    });
-                }
-            }
-        },
-        hideLicenseKey: function(el) {
-            const code = el.parentNode.parentNode.previousSibling.previousSibling;
-
-            code.innerText = '';
-            code.classList.add('empty');
-        },
-        showLicenseKey: function(el) {
-            const licenseKeyId = parseInt(el.dataset.id);
-            const spinner      = el.parentNode.parentNode.previousSibling;
-            const code         = spinner.previousSibling;
-
-            spinner.style.opacity = 1;
-
-            jQuery.ajax({
-                url: ajaxurl,
-                type: 'POST',
-                data: {
-                    action: 'lmfwc_show_license_key',
-                    show: license.show,
-                    id: licenseKeyId
-                },
-                success: function(response) {
-                    code.classList.remove('empty');
-                    code.innerText = response;
-                },
-                error: function(response) {
-                    console.log(response);
-                },
-                complete: function() {
-                    spinner.style.opacity = 0;
-                }
-            });
-        },
-        copyToClipboard: function(el, e) {
-            // Copy to clipboard
-            const str = el.innerText.toString();
-
-            if (!str) return;
-
-            const textArea = document.createElement('textarea');
-            textArea.value = str;
-            textArea.setAttribute('readonly', '');
-            textArea.style.position = 'absolute';
-            textArea.style.left = '-9999px';
-            document.body.appendChild(textArea);
-            const selected =
-                document.getSelection().rangeCount > 0
-                    ? document.getSelection().getRangeAt(0)
-                    : false;
-            textArea.select();
-            document.execCommand('copy');
-            document.body.removeChild(textArea);
-            if (selected) {
-                document.getSelection().removeAllRanges();
-                document.getSelection().addRange(selected);
-            }
-
-            // Display info
-            const copied = document.createElement('div');
-            copied.classList.add('lmfwc-clipboard');
-            copied.style.position = 'absolute';
-            copied.style.left = e.clientX.toString() + 'px';
-            copied.style.top = (window.pageYOffset + e.clientY).toString() + 'px';
-            copied.innerText = document.querySelector('.lmfwc-txt-copied-to-clipboard').innerText.toString();
-            document.body.appendChild(copied);
-
-            setTimeout(function() {
-                copied.style.opacity = '0';
-            }, 700);
-            setTimeout(function() {
-                document.body.removeChild(copied);
-            }, 1500);
-        },
-        init: function() {
-            this.bindEventListeners();
+        if (license.product_downloads && licenseKeysCheckbox.is( ':checked' )) {
+            modifyProductDownloadsTable();
+        } else {
+            resetProductDownloadsTable();
         }
-    };
+    } );
 
-    var orderLicenses = {
-        btnShow: document.querySelectorAll('.lmfwc-license-keys-show-all'),
-        btnHide: document.querySelectorAll('.lmfwc-license-keys-hide-all'),
-        getLicenseKeyIds: function(button) {
-            const licenseKeyIds = [];
-            const codeList = button.parentNode.previousSibling.children;
+    function registerClickHandlers( licenseKeysCheckbox ) {
+        $( '.lmfwc-license-key-show' ).click( function () {
+            showLicenseKey( this );
+        } );
 
-            for (let i = 0; i < codeList.length; i++) {
-                licenseKeyIds.push(parseInt(codeList[i].children[0].dataset.id));
-            }
+        $( document ).on( 'click', '.license_key .lmfwc-placeholder, .lmfwc-license-list .lmfwc-placeholder', function ( e ) {
+            copyLicenseKeyToClipboard( this, e );
+        } );
 
-            return licenseKeyIds;
-        },
-        bindShow: function() {
-            if (!this.btnShow) return;
+        $( '.lmfwc-license-key-hide' ).click( function () {
+            hideLicenseKey( this );
+        } );
 
-            const licenseTableObject = this;
+        $( '.lmfwc-license-keys-show-all' ).click( function () {
+            showAllLicenseKeys( this );
+        } );
 
-            for (let i = 0; i < this.btnShow.length; i++) {
-                const btnShow = this.btnShow[i];
+        $( '.lmfwc-license-keys-hide-all' ).click( function () {
+            hideAllLicenseKeys( this );
+        } );
 
-                btnShow.addEventListener('click', function() {
-                    const currentButton = this;
-                    const spinner       = currentButton.nextSibling.nextSibling;
-                    const licenseKeyIds = licenseTableObject.getLicenseKeyIds(currentButton);
-                    spinner.style.opacity = 1;
+        if (license.product_downloads) {
+            $( '#woocommerce-product-data .downloadable_files table .insert' ).click( function () {
+                if (licenseKeysCheckbox.is( ':checked' )) {
+                    modifyProductDownloadsTable( true );
+                }
+            } );
 
-                    jQuery.ajax({
-                        url: ajaxurl,
-                        type: 'POST',
-                        data: {
-                            action: 'lmfwc_show_all_license_keys',
-                            show_all: license.show_all,
-                            ids: JSON.stringify(licenseKeyIds)
-                        },
-                        success: function(response) {
-                            const licenseKeys = response;
-
-                            for (const id in licenseKeys) {
-                                if (!licenseKeys.hasOwnProperty(id)) {
-                                    continue;
-                                }
-
-                                const licenseKey = document.querySelector('.lmfwc-placeholder[data-id="' + id + '"]');
-                                licenseKey.classList.remove('empty');
-                                licenseKey.innerText = licenseKeys[id];
-                            }
-                        },
-                        error: function(response) {
-                            console.log(response);
-                        },
-                        complete: function() {
-                            spinner.style.opacity = 0;
-                        }
-                    });
-                });
-            }
-        },
-        bindHide: function() {
-            if (!this.btnHide) return;
-
-            const licenseTableObject = this;
-
-            for (let i = 0; i < this.btnHide.length; i++) {
-                const btnHide = this.btnHide[i];
-
-                btnHide.addEventListener('click', function() {
-                    const currentButton = this;
-                    const licenseKeyIds = licenseTableObject.getLicenseKeyIds(currentButton);
-
-                    for (const id in licenseKeyIds) {
-                        if (!licenseKeyIds.hasOwnProperty(id)) {
-                            continue;
-                        }
-
-                        const licenseKey = document.querySelector('.lmfwc-placeholder[data-id="' + licenseKeyIds[id] + '"]');
-                        licenseKey.classList.add('empty');
-                        licenseKey.innerText = '';
-                    }
-                });
-            }
-        },
-        init: function() {
-            this.bindShow();
-            this.bindHide();
+            $( '#woocommerce-product-data' ).on( 'click', '.downloadable_files table tr .delete', function () {
+                if (licenseKeysCheckbox.is( ':checked' )) {
+                    resetProductDownloadsTable();
+                }
+            } );
         }
-    };
+    }
 
-    licenseTable.init();
-    orderLicenses.init();
-});
+    function registerChangeHandlers() {
+        if (license.product_downloads) {
+            $( document ).on( 'change', '#lmfwc_licensed_product', function () {
+                if ($( this ).is( ':checked' )) {
+                    $( '.downloadable_files table tbody' ).find( 'tr:gt(0)' ).remove();
+                    modifyProductDownloadsTable();
+                } else {
+                    resetProductDownloadsTable();
+                }
+            } );
+        }
+    }
+
+    function showLicenseKey( el ) {
+        const licenseKeyId = parseInt( $( el ).data( 'id' ) );
+        const code         = $( el ).closest( '.license_key' ).find( '.lmfwc-placeholder' );
+
+        showLicenseKeyLoadingSpinner( el );
+
+        const data = {
+            action: 'lmfwc_show_license_key',
+            show: license.show,
+            id: licenseKeyId
+        };
+
+        $.post( ajaxurl, data, function () {
+        } ).done( function ( response ) {
+            code.removeClass( 'empty' );
+            code.text( response );
+        } ).fail( function ( response ) {
+            console.log( response );
+        } ).always( function () {
+            hideLicenseKeyLoadingSpinner( el );
+        } );
+    }
+
+    function hideLicenseKey( el ) {
+        const code = $( el ).closest( '.license_key' ).find( '.lmfwc-placeholder' );
+
+        code.text( '' );
+        code.addClass( 'empty' );
+    }
+
+    function showAllLicenseKeys( el ) {
+        const licenseKeyIds = getAllLicenseKeyIds( el );
+
+        showLicenseKeyLoadingSpinner( el );
+
+        const data = {
+            action: 'lmfwc_show_all_license_keys',
+            show_all: license.show_all,
+            ids: JSON.stringify( licenseKeyIds )
+        };
+
+        $.post( ajaxurl, data, function () {
+        } ).done( function ( response ) {
+            for (const id in response) {
+                if (!response.hasOwnProperty( id )) {
+                    continue;
+                }
+
+                const licenseKey = $( '.lmfwc-placeholder[data-id="' + id + '"]' );
+
+                licenseKey.removeClass( 'empty' );
+                licenseKey.text( response[id] );
+            }
+        } ).fail( function ( response ) {
+            console.log( response );
+        } ).always( function () {
+            hideLicenseKeyLoadingSpinner( el );
+        } );
+    }
+
+    function hideAllLicenseKeys( el ) {
+        const licenseKeyIds = getAllLicenseKeyIds( el );
+
+        $( licenseKeyIds ).each( function ( id, value ) {
+            const licenseKey = $( '.lmfwc-placeholder[data-id="' + value + '"]' );
+
+            licenseKey.addClass( 'empty' );
+            licenseKey.text( '' );
+        } );
+
+        for (const id in licenseKeyIds) {
+            if (!licenseKeyIds.hasOwnProperty( id )) {
+                continue;
+            }
+
+            const licenseKey = $( '.lmfwc-placeholder[data-id="' + id + '"]' );
+
+            licenseKey.addClass( 'empty' );
+            licenseKey.text( '' );
+        }
+    }
+
+    function getAllLicenseKeyIds( el ) {
+        const licenseKeyIds = [];
+        const codeList      = $( el ).closest( 'td' ).find( '.lmfwc-license-list li' );
+
+        codeList.each( function ( id, li ) {
+            licenseKeyIds.push( parseInt( $( li ).find( '.lmfwc-placeholder' ).data( 'id' ) ) );
+        } );
+
+        return licenseKeyIds;
+    }
+
+    function copyLicenseKeyToClipboard( el, e ) {
+        const str = $( el ).text();
+
+        if (str.length === 0) {
+            return;
+        }
+
+        const textArea = document.createElement( 'textarea' );
+        textArea.value = str;
+        textArea.setAttribute( 'readonly', '' );
+        textArea.style.position = 'absolute';
+        textArea.style.left     = '-9999px';
+        document.body.appendChild( textArea );
+        const selected = document.getSelection().rangeCount > 0 ? document.getSelection().getRangeAt( 0 ) : false;
+        textArea.select();
+        document.execCommand( 'copy' );
+        document.body.removeChild( textArea );
+        if (selected) {
+            document.getSelection().removeAllRanges();
+            document.getSelection().addRange( selected );
+        }
+
+        // Display info
+        const copied = document.createElement( 'div' );
+        copied.classList.add( 'lmfwc-clipboard' );
+        copied.style.position = 'absolute';
+        copied.style.left     = e.clientX.toString() + 'px';
+        copied.style.top      = (window.pageYOffset + e.clientY).toString() + 'px';
+        copied.innerText      = document.querySelector( '.lmfwc-txt-copied-to-clipboard' ).innerText.toString();
+        document.body.appendChild( copied );
+
+        setTimeout( function () {
+            copied.style.opacity = '0';
+        }, 700 );
+        setTimeout( function () {
+            document.body.removeChild( copied );
+        }, 1500 );
+    }
+
+    function showLicenseKeyLoadingSpinner( el ) {
+        $( el ).closest( 'td' ).find( '.lmfwc-spinner' ).css( 'opacity', 1 );
+    }
+
+    function hideLicenseKeyLoadingSpinner( el ) {
+        $( el ).closest( 'td' ).find( '.lmfwc-spinner' ).css( 'opacity', 0 );
+    }
+
+    function modifyProductDownloadsTable( insertButton = false ) {
+        let productDownloadsTableRowCount = $( '.downloadable_files table tbody tr' ).length;
+
+        if ((!insertButton && productDownloadsTableRowCount >= 1) || (insertButton && productDownloadsTableRowCount >= 0)) {
+            $( '.downloadable_files table tfoot' ).css( 'display', 'none' );
+        } else {
+            resetProductDownloadsTable();
+        }
+    }
+
+    function resetProductDownloadsTable() {
+        $( '.downloadable_files table tfoot' ).css( 'display', 'table-footer-group' );
+    }
+})( jQuery );

--- a/includes/Main.php
+++ b/includes/Main.php
@@ -117,7 +117,7 @@ final class Main extends Singleton
         wp_enqueue_script(
             'lmfwc_admin_js',
             LMFWC_JS_URL . 'script.js',
-            array(),
+	        array( 'jquery' ),
             $this->version
         );
 
@@ -196,9 +196,10 @@ final class Main extends Singleton
             'lmfwc_admin_js',
             'license',
             array(
-                'show'     => wp_create_nonce('lmfwc_show_license_key'),
-                'show_all' => wp_create_nonce('lmfwc_show_all_license_keys'),
-            )
+                'show'              => wp_create_nonce('lmfwc_show_license_key'),
+                'show_all'          => wp_create_nonce('lmfwc_show_all_license_keys'),
+	            'product_downloads' => Settings::get( 'lmfwc_product_downloads' )
+             )
         );
     }
 

--- a/includes/Main.php
+++ b/includes/Main.php
@@ -117,7 +117,7 @@ final class Main extends Singleton
         wp_enqueue_script(
             'lmfwc_admin_js',
             LMFWC_JS_URL . 'script.js',
-	        array( 'jquery' ),
+            array('jquery'),
             $this->version
         );
 
@@ -198,8 +198,8 @@ final class Main extends Singleton
             array(
                 'show'              => wp_create_nonce('lmfwc_show_license_key'),
                 'show_all'          => wp_create_nonce('lmfwc_show_all_license_keys'),
-	            'product_downloads' => Settings::get( 'lmfwc_product_downloads' )
-             )
+                'product_downloads' => Settings::get( 'lmfwc_product_downloads' )
+            )
         );
     }
 

--- a/includes/Setup.php
+++ b/includes/Setup.php
@@ -335,7 +335,8 @@ class Setup
                 '019' => '1',
                 '020' => '1',
                 '021' => '1',
-                '022' => '1'
+                '022' => '1',
+                '023' => '1'
             )
         );
         $defaultSettingsOrderStatus = array(

--- a/includes/Setup.php
+++ b/includes/Setup.php
@@ -309,6 +309,8 @@ class Setup
         $defaultSettingsGeneral = array(
             'lmfwc_hide_license_keys' => 0,
             'lmfwc_auto_delivery' => 1,
+            'lmfwc_product_downloads' => 1,
+            'lmfwc_download_expires' => 1,
             'lmfwc_disable_api_ssl' => 0,
             'lmfwc_enabled_api_routes' => array(
                 '000' => '1',
@@ -331,7 +333,9 @@ class Setup
                 '017' => '1',
                 '018' => '1',
                 '019' => '1',
-                '020' => '1'
+                '020' => '1',
+                '021' => '1',
+                '022' => '1'
             )
         );
         $defaultSettingsOrderStatus = array(

--- a/includes/api/Setup.php
+++ b/includes/api/Setup.php
@@ -31,6 +31,7 @@ class Setup
         $controllers = array(
             // REST API v2 controllers.
             '\LicenseManagerForWooCommerce\API\v2\Licenses',
+            '\LicenseManagerForWooCommerce\API\v2\Products',
             '\LicenseManagerForWooCommerce\API\v2\Generators'
         );
 

--- a/includes/api/v2/Generators.php
+++ b/includes/api/v2/Generators.php
@@ -459,9 +459,16 @@ class Generators extends LMFWC_REST_Controller
         return $this->response(true, $updatedGenerator->toArray(), 200, 'v2/generators/{id}');
     }
 
+    /**
+     * Callback for the POST generators/{id}/generate route. Creates licenses
+     * using a generator with a save option.
+     *
+     * @param WP_REST_Request $request
+     * @return WP_REST_Response|WP_Error
+     */
     public function generateLicenseKeys(WP_REST_Request $request)
     {
-        if (!$this->isRouteEnabled($this->settings, '020')) {
+        if (!$this->isRouteEnabled($this->settings, '021')) {
             return $this->routeDisabledError();
         }
 

--- a/includes/api/v2/Products.php
+++ b/includes/api/v2/Products.php
@@ -1,0 +1,303 @@
+<?php
+
+namespace LicenseManagerForWooCommerce\API\v2;
+
+use Exception;
+use LicenseManagerForWooCommerce\Abstracts\RestController as LMFWC_REST_Controller;
+use LicenseManagerForWooCommerce\Models\Resources\License as LicenseResourceModel;
+use LicenseManagerForWooCommerce\Repositories\Resources\License as LicenseResourceRepository;
+use WP_Error;
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_REST_Server;
+
+defined( 'ABSPATH' ) || exit;
+
+class Products extends LMFWC_REST_Controller {
+	/**
+	 * @var string
+	 */
+	protected $namespace = 'lmfwc/v2';
+
+	/**
+	 * @var string
+	 */
+	protected $rest_base = '/products';
+
+	/**
+	 * @var array
+	 */
+	protected $settings = array();
+
+	/**
+	 * Licenses constructor.
+	 */
+	public function __construct() {
+		$this->settings = (array) get_option( 'lmfwc_settings_general' );
+	}
+
+	/**
+	 * Register all the needed routes for this resource.
+	 */
+	public function register_routes() {
+		/**
+		 * GET products/update/{license_key}
+		 *
+		 * Retrieves update information's about a WooCommerce product e.g. a WordPress plugin
+		 */
+		register_rest_route(
+			$this->namespace, $this->rest_base . '/update/(?P<license_key>[\w-]+)', array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'checkProductUpdate' ),
+					'permission_callback' => array( $this, 'permissionCallback' ),
+					'args'                => array(
+						'license_key' => array(
+							'description' => 'License Key',
+							'type'        => 'string',
+						)
+					)
+				)
+			)
+		);
+
+		/**
+		 * GET products/download/{license_key}
+		 *
+		 * Deliver update file for a WooCommerce product e.g. a WordPress plugin
+		 */
+		register_rest_route(
+			$this->namespace, $this->rest_base . '/download/latest/(?P<license_key>[\w-]+)', array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'downloadProductUpdate' ),
+					'permission_callback' => array( $this, 'permissionCallback' ),
+					'args'                => array(
+						'license_key' => array(
+							'description' => 'License Key',
+							'type'        => 'string',
+						)
+					)
+				)
+			)
+		);
+	}
+
+	/**
+	 * Callback for the GET products/update/{license_key} route. Retrieves a single license key from the database.
+	 *
+	 * @param WP_REST_Request $request
+	 *
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function checkProductUpdate( WP_REST_Request $request ) {
+		if ( ! $this->isRouteEnabled( $this->settings, '021' ) ) {
+			return $this->routeDisabledError();
+		}
+
+		if ( ! $this->permissionCheck( 'license', 'read' ) ) {
+			return new WP_Error(
+				'lmfwc_rest_cannot_view',
+				__( 'Sorry, you cannot view this resource.', 'license-manager-for-woocommerce' ),
+				array(
+					'status' => $this->authorizationRequiredCode()
+				)
+			);
+		}
+
+		$licenseKey = sanitize_text_field( $request->get_param( 'license_key' ) );
+
+		if ( ! $licenseKey ) {
+			return new WP_Error(
+				'lmfwc_rest_data_error',
+				'License Key ID invalid.',
+				array( 'status' => 404 )
+			);
+		}
+
+		try {
+			/** @var LicenseResourceModel $license */
+			$license = LicenseResourceRepository::instance()->findBy(
+				array(
+					'hash' => apply_filters( 'lmfwc_hash', $licenseKey )
+				)
+			);
+		} catch ( Exception $e ) {
+			return new WP_Error(
+				'lmfwc_rest_data_error',
+				$e->getMessage(),
+				array( 'status' => 404 )
+			);
+		}
+
+		if ( ! $license ) {
+			return new WP_Error(
+				'lmfwc_rest_data_error',
+				sprintf(
+					'License Key: %s could not be found.',
+					$licenseKey
+				),
+				array( 'status' => 404 )
+			);
+		}
+
+		$productId = $license->getProductId();
+
+		if ( ! $productId ) {
+			return new WP_Error(
+				'lmfwc_rest_data_error',
+				'No product assigned to license.',
+				array( 'status' => 404 )
+			);
+		}
+
+		$decryptedLicenseKey = $license->getDecryptedLicenseKey();
+		$product             = wc_get_product( $license->getProductId() );
+		$productDownloads    = $product->get_downloads();
+
+		if ( ! empty( $productDownloads ) ) {
+			$productDownloadFile = ABSPATH . ltrim( wp_make_link_relative( $product->get_file_download_path( array_key_first( $productDownloads ) ) ), '/' );
+
+			if ( file_exists( $productDownloadFile ) ) {
+				$lastUpdated = date( 'Y-m-d H:i:s', filemtime( $productDownloadFile ) );
+			}
+		}
+
+        $consumerKey    = '';
+        $consumerSecret = '';
+
+        // If the $_GET parameters are present, use those first.
+        if ( ! empty( $_GET['consumer_key'] ) && ! empty( $_GET['consumer_secret'] ) ) {
+            $consumerKey    = $_GET['consumer_key'];
+            $consumerSecret = $_GET['consumer_secret'];
+        }
+
+        // If the above is not present, we will do full basic auth.
+        if ( ! $consumerKey && ! empty( $_SERVER['PHP_AUTH_USER'] ) && ! empty( $_SERVER['PHP_AUTH_PW'] ) ) {
+            $consumerKey    = $_SERVER['PHP_AUTH_USER'];
+            $consumerSecret = $_SERVER['PHP_AUTH_PW'];
+        }
+
+        // Add key and secret to update url
+        $package_url = add_query_arg( [
+            'consumer_key'    => $consumerKey,
+            'consumer_secret' => $consumerSecret
+        ], get_rest_url() . $this->namespace . $this->rest_base . '/download/latest/' . $decryptedLicenseKey );
+
+        $updateData = [
+            'license_key'  => $license->getDecryptedLicenseKey(),
+            'url'          => $product->get_permalink(),
+            'new_version'  => $product->get_meta( 'lmfwc_licensed_product_version' ),
+            'package'      => $package_url, // Link to download the latest update
+            'tested'       => $product->get_meta( 'lmfwc_licensed_product_tested' ), // Testes up to WP version
+            'requires'     => $product->get_meta( 'lmfwc_licensed_product_requires' ), // Required WP version
+            'requires_php' => $product->get_meta( 'lmfwc_licensed_product_requires_php' ),
+            'last_updated' => $lastUpdated ?? '',
+            'sections'     => [
+                'changelog' => preg_replace( "/\r\n|\r|\n/", '', wpautop( $product->get_meta( 'lmfwc_licensed_product_changelog' ) ) )
+            ]
+        ];
+
+		return $this->response( true, $updateData, 200, 'v2/products/update/{license_key}' );
+	}
+
+	/**
+	 * Callback for the GET products/download/{license_key} route. Retrieves a single license key from the database.
+	 *
+	 * @param WP_REST_Request $request
+	 *
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function downloadProductUpdate( WP_REST_Request $request ) {
+		if ( ! $this->isRouteEnabled( $this->settings, '022' ) ) {
+			return $this->routeDisabledError();
+		}
+
+		if ( ! $this->permissionCheck( 'license', 'read' ) ) {
+			return new WP_Error(
+				'lmfwc_rest_cannot_view',
+				__( 'Sorry, you cannot view this resource.', 'license-manager-for-woocommerce' ),
+				array(
+					'status' => $this->authorizationRequiredCode()
+				)
+			);
+		}
+
+		$licenseKey = sanitize_text_field( $request->get_param( 'license_key' ) );
+
+		if ( ! $licenseKey ) {
+			return new WP_Error(
+				'lmfwc_rest_data_error',
+				'License Key ID invalid.',
+				array( 'status' => 404 )
+			);
+		}
+
+		try {
+			/** @var LicenseResourceModel $license */
+			$license = LicenseResourceRepository::instance()->findBy(
+				array(
+					'hash' => apply_filters( 'lmfwc_hash', $licenseKey )
+				)
+			);
+		} catch ( Exception $e ) {
+			return new WP_Error(
+				'lmfwc_rest_data_error',
+				$e->getMessage(),
+				array( 'status' => 404 )
+			);
+		}
+
+		if ( ! $license ) {
+			return new WP_Error(
+				'lmfwc_rest_data_error',
+				sprintf(
+					'License Key: %s could not be found.',
+					$licenseKey
+				),
+				array( 'status' => 404 )
+			);
+		}
+
+		$productId = $license->getProductId();
+
+		if ( ! $productId ) {
+			return new WP_Error(
+				'lmfwc_rest_data_error',
+				'No product assigned to license.',
+				array( 'status' => 404 )
+			);
+		}
+
+		$product             = wc_get_product( $license->getProductId() );
+		$productDownloads    = $product->get_downloads();
+		$productDownloadFile = ABSPATH . ltrim( wp_make_link_relative( $product->get_file_download_path( array_key_first( $productDownloads ) ) ), '/' );
+
+		if ( empty( $productDownloadFile ) || ! file_exists( $productDownloadFile ) ) {
+			return new WP_Error(
+				'lmfwc_rest_data_error',
+				'Requested file not found.',
+				array( 'status' => 404 )
+			);
+		}
+
+        header( 'Content-Description: File Transfer' );
+        header( 'Content-Type: application/octet-stream' );
+        header( 'Content-Disposition: attachment; filename=' . basename( $productDownloadFile ) );
+        header( 'Content-Transfer-Encoding: binary' );
+        header( 'Expires: 0' );
+        header( 'Cache-Control: must-revalidate, post-check=0, pre-check=0' );
+        header( 'Pragma: public' );
+        header( 'Content-Length: ' . filesize( $productDownloadFile ) );
+        ob_clean();
+        flush();
+        readfile( $productDownloadFile );
+
+        $fileDetailsData = [
+            'filename'       => basename( $productDownloadFile ),
+            'content-length' => filesize( $productDownloadFile )
+        ];
+
+        return $this->response( true, $fileDetailsData, 200, 'v2/products/download/latest/{license_key}' );
+	}
+}

--- a/includes/api/v2/Products.php
+++ b/includes/api/v2/Products.php
@@ -14,154 +14,155 @@ use WP_REST_Server;
 defined( 'ABSPATH' ) || exit;
 
 class Products extends LMFWC_REST_Controller {
-	/**
-	 * @var string
-	 */
-	protected $namespace = 'lmfwc/v2';
+    /**
+     * @var string
+     */
+    protected $namespace = 'lmfwc/v2';
 
-	/**
-	 * @var string
-	 */
-	protected $rest_base = '/products';
+    /**
+     * @var string
+     */
+    protected $rest_base = '/products';
 
-	/**
-	 * @var array
-	 */
-	protected $settings = array();
+    /**
+     * @var array
+     */
+    protected $settings = array();
 
-	/**
-	 * Licenses constructor.
-	 */
-	public function __construct() {
-		$this->settings = (array) get_option( 'lmfwc_settings_general' );
-	}
+    /**
+     * Licenses constructor.
+     */
+    public function __construct() {
+        $this->settings = get_option( 'lmfwc_settings_general', array() );
+    }
 
-	/**
-	 * Register all the needed routes for this resource.
-	 */
-	public function register_routes() {
-		/**
-		 * GET products/update/{license_key}
-		 *
-		 * Retrieves update information's about a WooCommerce product e.g. a WordPress plugin
-		 */
-		register_rest_route(
-			$this->namespace, $this->rest_base . '/update/(?P<license_key>[\w-]+)', array(
-				array(
-					'methods'             => WP_REST_Server::READABLE,
-					'callback'            => array( $this, 'checkProductUpdate' ),
-					'permission_callback' => array( $this, 'permissionCallback' ),
-					'args'                => array(
-						'license_key' => array(
-							'description' => 'License Key',
-							'type'        => 'string',
-						)
-					)
-				)
-			)
-		);
+    /**
+     * Register all the needed routes for this resource.
+     */
+    public function register_routes() {
+        /**
+         * GET products/update/{license_key}
+         *
+         * Retrieves update information's about a WooCommerce product e.g. a WordPress plugin
+         */
+        register_rest_route(
+            $this->namespace, $this->rest_base . '/update/(?P<license_key>[\w-]+)', array(
+                array(
+                    'methods'             => WP_REST_Server::READABLE,
+                    'callback'            => array( $this, 'checkProductUpdate' ),
+                    'permission_callback' => array( $this, 'permissionCallback' ),
+                    'args'                => array(
+                        'license_key' => array(
+                            'description' => 'License Key',
+                            'type'        => 'string',
+                        )
+                    )
+                )
+            )
+        );
 
-		/**
-		 * GET products/download/{license_key}
-		 *
-		 * Deliver update file for a WooCommerce product e.g. a WordPress plugin
-		 */
-		register_rest_route(
-			$this->namespace, $this->rest_base . '/download/latest/(?P<license_key>[\w-]+)', array(
-				array(
-					'methods'             => WP_REST_Server::READABLE,
-					'callback'            => array( $this, 'downloadProductUpdate' ),
-					'permission_callback' => array( $this, 'permissionCallback' ),
-					'args'                => array(
-						'license_key' => array(
-							'description' => 'License Key',
-							'type'        => 'string',
-						)
-					)
-				)
-			)
-		);
-	}
+        /**
+         * GET products/download/{license_key}
+         *
+         * Deliver update file for a WooCommerce product e.g. a WordPress plugin
+         */
+        register_rest_route(
+            $this->namespace, $this->rest_base . '/download/latest/(?P<license_key>[\w-]+)', array(
+                array(
+                    'methods'             => WP_REST_Server::READABLE,
+                    'callback'            => array( $this, 'downloadProductUpdate' ),
+                    'permission_callback' => array( $this, 'permissionCallback' ),
+                    'args'                => array(
+                        'license_key' => array(
+                            'description' => 'License Key',
+                            'type'        => 'string',
+                        )
+                    )
+                )
+            )
+        );
+    }
 
-	/**
-	 * Callback for the GET products/update/{license_key} route. Retrieves a single license key from the database.
-	 *
-	 * @param WP_REST_Request $request
-	 *
-	 * @return WP_REST_Response|WP_Error
-	 */
-	public function checkProductUpdate( WP_REST_Request $request ) {
-		if ( ! $this->isRouteEnabled( $this->settings, '021' ) ) {
-			return $this->routeDisabledError();
-		}
+    /**
+     * Callback for the GET products/update/{license_key} route. Checks if a
+     * product update is available.
+     *
+     * @param WP_REST_Request $request
+     *
+     * @return WP_REST_Response|WP_Error
+     */
+    public function checkProductUpdate( WP_REST_Request $request ) {
+        if ( ! $this->isRouteEnabled( $this->settings, '022' ) ) {
+            return $this->routeDisabledError();
+        }
 
-		if ( ! $this->permissionCheck( 'license', 'read' ) ) {
-			return new WP_Error(
-				'lmfwc_rest_cannot_view',
-				__( 'Sorry, you cannot view this resource.', 'license-manager-for-woocommerce' ),
-				array(
-					'status' => $this->authorizationRequiredCode()
-				)
-			);
-		}
+        if ( ! $this->permissionCheck( 'license', 'read' ) ) {
+            return new WP_Error(
+                'lmfwc_rest_cannot_view',
+                __( 'Sorry, you cannot view this resource.', 'license-manager-for-woocommerce' ),
+                array(
+                    'status' => $this->authorizationRequiredCode()
+                )
+            );
+        }
 
-		$licenseKey = sanitize_text_field( $request->get_param( 'license_key' ) );
+        $licenseKey = sanitize_text_field( $request->get_param( 'license_key' ) );
 
-		if ( ! $licenseKey ) {
-			return new WP_Error(
-				'lmfwc_rest_data_error',
-				'License Key ID invalid.',
-				array( 'status' => 404 )
-			);
-		}
+        if ( ! $licenseKey ) {
+            return new WP_Error(
+                'lmfwc_rest_data_error',
+                'License Key ID invalid.',
+                array( 'status' => 404 )
+            );
+        }
 
-		try {
-			/** @var LicenseResourceModel $license */
-			$license = LicenseResourceRepository::instance()->findBy(
-				array(
-					'hash' => apply_filters( 'lmfwc_hash', $licenseKey )
-				)
-			);
-		} catch ( Exception $e ) {
-			return new WP_Error(
-				'lmfwc_rest_data_error',
-				$e->getMessage(),
-				array( 'status' => 404 )
-			);
-		}
+        try {
+            /** @var LicenseResourceModel $license */
+            $license = LicenseResourceRepository::instance()->findBy(
+                array(
+                    'hash' => apply_filters( 'lmfwc_hash', $licenseKey )
+                )
+            );
+        } catch ( Exception $e ) {
+            return new WP_Error(
+                'lmfwc_rest_data_error',
+                $e->getMessage(),
+                array( 'status' => 404 )
+            );
+        }
 
-		if ( ! $license ) {
-			return new WP_Error(
-				'lmfwc_rest_data_error',
-				sprintf(
-					'License Key: %s could not be found.',
-					$licenseKey
-				),
-				array( 'status' => 404 )
-			);
-		}
+        if ( ! $license ) {
+            return new WP_Error(
+                'lmfwc_rest_data_error',
+                sprintf(
+                    'License Key: %s could not be found.',
+                    $licenseKey
+                ),
+                array( 'status' => 404 )
+            );
+        }
 
-		$productId = $license->getProductId();
+        $productId = $license->getProductId();
 
-		if ( ! $productId ) {
-			return new WP_Error(
-				'lmfwc_rest_data_error',
-				'No product assigned to license.',
-				array( 'status' => 404 )
-			);
-		}
+        if ( ! $productId ) {
+            return new WP_Error(
+                'lmfwc_rest_data_error',
+                'No product assigned to license.',
+                array( 'status' => 404 )
+            );
+        }
 
-		$decryptedLicenseKey = $license->getDecryptedLicenseKey();
-		$product             = wc_get_product( $license->getProductId() );
-		$productDownloads    = $product->get_downloads();
+        $decryptedLicenseKey = $license->getDecryptedLicenseKey();
+        $product             = wc_get_product( $license->getProductId() );
+        $productDownloads    = $product->get_downloads();
 
-		if ( ! empty( $productDownloads ) ) {
-			$productDownloadFile = ABSPATH . ltrim( wp_make_link_relative( $product->get_file_download_path( array_key_first( $productDownloads ) ) ), '/' );
+        if ( ! empty( $productDownloads ) ) {
+            $productDownloadFile = ABSPATH . ltrim( wp_make_link_relative( $product->get_file_download_path( lmfwc_array_key_first( $productDownloads ) ) ), '/' );
 
-			if ( file_exists( $productDownloadFile ) ) {
-				$lastUpdated = date( 'Y-m-d H:i:s', filemtime( $productDownloadFile ) );
-			}
-		}
+            if ( file_exists( $productDownloadFile ) ) {
+                $lastUpdated = date( 'Y-m-d H:i:s', filemtime( $productDownloadFile ) );
+            }
+        }
 
         $consumerKey    = '';
         $consumerSecret = '';
@@ -179,7 +180,7 @@ class Products extends LMFWC_REST_Controller {
         }
 
         // Add key and secret to update url
-        $package_url = add_query_arg( [
+        $packageUrl = add_query_arg( [
             'consumer_key'    => $consumerKey,
             'consumer_secret' => $consumerSecret
         ], get_rest_url() . $this->namespace . $this->rest_base . '/download/latest/' . $decryptedLicenseKey );
@@ -188,98 +189,99 @@ class Products extends LMFWC_REST_Controller {
             'license_key'  => $license->getDecryptedLicenseKey(),
             'url'          => $product->get_permalink(),
             'new_version'  => $product->get_meta( 'lmfwc_licensed_product_version' ),
-            'package'      => $package_url, // Link to download the latest update
+            'package'      => $packageUrl, // Link to download the latest update
             'tested'       => $product->get_meta( 'lmfwc_licensed_product_tested' ), // Testes up to WP version
             'requires'     => $product->get_meta( 'lmfwc_licensed_product_requires' ), // Required WP version
             'requires_php' => $product->get_meta( 'lmfwc_licensed_product_requires_php' ),
-            'last_updated' => $lastUpdated ?? '',
+            'last_updated' => isset($lastUpdated) ? $lastUpdated : '',
             'sections'     => [
                 'changelog' => preg_replace( "/\r\n|\r|\n/", '', wpautop( $product->get_meta( 'lmfwc_licensed_product_changelog' ) ) )
             ]
         ];
 
-		return $this->response( true, $updateData, 200, 'v2/products/update/{license_key}' );
-	}
+        return $this->response( true, $updateData, 200, 'v2/products/update/{license_key}' );
+    }
 
-	/**
-	 * Callback for the GET products/download/{license_key} route. Retrieves a single license key from the database.
-	 *
-	 * @param WP_REST_Request $request
-	 *
-	 * @return WP_REST_Response|WP_Error
-	 */
-	public function downloadProductUpdate( WP_REST_Request $request ) {
-		if ( ! $this->isRouteEnabled( $this->settings, '022' ) ) {
-			return $this->routeDisabledError();
-		}
+    /**
+     * Callback for the GET products/download/{license_key} route. Performs a
+     * product download.
+     *
+     * @param WP_REST_Request $request
+     *
+     * @return WP_REST_Response|WP_Error
+     */
+    public function downloadProductUpdate( WP_REST_Request $request ) {
+        if ( ! $this->isRouteEnabled( $this->settings, '023' ) ) {
+            return $this->routeDisabledError();
+        }
 
-		if ( ! $this->permissionCheck( 'license', 'read' ) ) {
-			return new WP_Error(
-				'lmfwc_rest_cannot_view',
-				__( 'Sorry, you cannot view this resource.', 'license-manager-for-woocommerce' ),
-				array(
-					'status' => $this->authorizationRequiredCode()
-				)
-			);
-		}
+        if ( ! $this->permissionCheck( 'license', 'read' ) ) {
+            return new WP_Error(
+                'lmfwc_rest_cannot_view',
+                __( 'Sorry, you cannot view this resource.', 'license-manager-for-woocommerce' ),
+                array(
+                    'status' => $this->authorizationRequiredCode()
+                )
+            );
+        }
 
-		$licenseKey = sanitize_text_field( $request->get_param( 'license_key' ) );
+        $licenseKey = sanitize_text_field( $request->get_param( 'license_key' ) );
 
-		if ( ! $licenseKey ) {
-			return new WP_Error(
-				'lmfwc_rest_data_error',
-				'License Key ID invalid.',
-				array( 'status' => 404 )
-			);
-		}
+        if ( ! $licenseKey ) {
+            return new WP_Error(
+                'lmfwc_rest_data_error',
+                'License Key ID invalid.',
+                array( 'status' => 404 )
+            );
+        }
 
-		try {
-			/** @var LicenseResourceModel $license */
-			$license = LicenseResourceRepository::instance()->findBy(
-				array(
-					'hash' => apply_filters( 'lmfwc_hash', $licenseKey )
-				)
-			);
-		} catch ( Exception $e ) {
-			return new WP_Error(
-				'lmfwc_rest_data_error',
-				$e->getMessage(),
-				array( 'status' => 404 )
-			);
-		}
+        try {
+            /** @var LicenseResourceModel $license */
+            $license = LicenseResourceRepository::instance()->findBy(
+                array(
+                    'hash' => apply_filters( 'lmfwc_hash', $licenseKey )
+                )
+            );
+        } catch ( Exception $e ) {
+            return new WP_Error(
+                'lmfwc_rest_data_error',
+                $e->getMessage(),
+                array( 'status' => 404 )
+            );
+        }
 
-		if ( ! $license ) {
-			return new WP_Error(
-				'lmfwc_rest_data_error',
-				sprintf(
-					'License Key: %s could not be found.',
-					$licenseKey
-				),
-				array( 'status' => 404 )
-			);
-		}
+        if ( ! $license ) {
+            return new WP_Error(
+                'lmfwc_rest_data_error',
+                sprintf(
+                    'License Key: %s could not be found.',
+                    $licenseKey
+                ),
+                array( 'status' => 404 )
+            );
+        }
 
-		$productId = $license->getProductId();
+        $productId = $license->getProductId();
 
-		if ( ! $productId ) {
-			return new WP_Error(
-				'lmfwc_rest_data_error',
-				'No product assigned to license.',
-				array( 'status' => 404 )
-			);
-		}
+        if ( ! $productId ) {
+            return new WP_Error(
+                'lmfwc_rest_data_error',
+                'No product assigned to license.',
+                array( 'status' => 404 )
+            );
+        }
 
-		$product             = wc_get_product( $license->getProductId() );
-		$productDownloads    = $product->get_downloads();
-		$productDownloadFile = ABSPATH . ltrim( wp_make_link_relative( $product->get_file_download_path( array_key_first( $productDownloads ) ) ), '/' );
+        $product             = wc_get_product( $license->getProductId() );
+        $productDownloads    = $product->get_downloads();
+        $productDownloadFile = ABSPATH . ltrim( wp_make_link_relative( $product->get_file_download_path( lmfwc_array_key_first( $productDownloads ) ) ), '/' );
 
-		if ( empty( $productDownloadFile ) || ! file_exists( $productDownloadFile ) ) {
-			return new WP_Error(
-				'lmfwc_rest_data_error',
-				'Requested file not found.',
-				array( 'status' => 404 )
-			);
-		}
+        if ( empty( $productDownloadFile ) || ! file_exists( $productDownloadFile ) ) {
+            return new WP_Error(
+                'lmfwc_rest_data_error',
+                'Requested file not found.',
+                array( 'status' => 404 )
+            );
+        }
 
         header( 'Content-Description: File Transfer' );
         header( 'Content-Type: application/octet-stream' );
@@ -293,11 +295,11 @@ class Products extends LMFWC_REST_Controller {
         flush();
         readfile( $productDownloadFile );
 
-        $fileDetailsData = [
+        $fileDetailsData = array(
             'filename'       => basename( $productDownloadFile ),
             'content-length' => filesize( $productDownloadFile )
-        ];
+        );
 
         return $this->response( true, $fileDetailsData, 200, 'v2/products/download/latest/{license_key}' );
-	}
+    }
 }

--- a/includes/controllers/License.php
+++ b/includes/controllers/License.php
@@ -2,22 +2,17 @@
 
 namespace LicenseManagerForWooCommerce\Controllers;
 
-use DateInterval;
-use DateTime;
-use DateTimeZone;
 use Exception;
-use LicenseManagerForWooCommerce\Abstracts\Singleton;
 use LicenseManagerForWooCommerce\AdminMenus;
 use LicenseManagerForWooCommerce\AdminNotice;
 use LicenseManagerForWooCommerce\Enums\LicenseSource;
 use LicenseManagerForWooCommerce\Enums\LicenseStatus as LicenseStatusEnum;
-use LicenseManagerForWooCommerce\Integrations\WooCommerce\Order;
 use LicenseManagerForWooCommerce\Models\Resources\License as LicenseResourceModel;
 use LicenseManagerForWooCommerce\Repositories\Resources\License as LicenseResourceRepository;
 
 defined('ABSPATH') || exit;
 
-class License extends Singleton
+class License
 {
     /**
      * License constructor.
@@ -214,12 +209,12 @@ class License extends Singleton
         );
 
         // Redirect with message
-	    if ( $license ) {
-	        if ( ! $expiresAt && $validFor ) {
-		        $expiresAt = $this->validFor2ExpiresAt( $validFor );
-	        }
+        if ($license) {
+            if (!$expiresAt && $validFor) {
+                $expiresAt = lmfwc_convert_valid_for_to_expires_at($validFor);
+            }
 
-	        Order::instance()->updateOrderDownloadsExpiration( $expiresAt, $orderId );
+            lmfwc_update_order_downloads_expiration($expiresAt, $orderId);
 
             AdminNotice::success(__('1 license key(s) added successfully.', 'license-manager-for-woocommerce'));
 
@@ -320,11 +315,11 @@ class License extends Singleton
                 apply_filters('lmfwc_stock_increase', $license->getProductId());
             }
 
-		    if ( ! $expiresAt && $validFor ) {
-			    $expiresAt = $this->validFor2ExpiresAt( $validFor );
-		    }
+            if ( ! $expiresAt && $validFor ) {
+                $expiresAt = lmfwc_convert_valid_for_to_expires_at($validFor);
+            }
 
-	        Order::instance()->updateOrderDownloadsExpiration( $expiresAt, $orderId );
+            lmfwc_update_order_downloads_expiration( $expiresAt, $orderId );
 
             // Display a success message
             AdminNotice::success(__('Your license key has been updated successfully.', 'license-manager-for-woocommerce'));
@@ -382,19 +377,4 @@ class License extends Singleton
 
         wp_send_json($licenseKeysIds);
     }
-
-	/**
-	 * Turn valid for into expires at date
-	 */
-	public function validFor2ExpiresAt( $validFor )
-	{
-		if ( ! empty( $validFor ) ) {
-			$date         = new DateTime( 'now', new DateTimeZone( 'GMT' ) );
-			$dateInterval = new DateInterval( 'P' . $validFor . 'D' );
-
-			return $date->add( $dateInterval )->format( 'Y-m-d H:i:s' );
-		}
-
-		return null;
-	}
 }

--- a/includes/integrations/woocommerce/Controller.php
+++ b/includes/integrations/woocommerce/Controller.php
@@ -15,8 +15,6 @@ use LicenseManagerForWooCommerce\Models\Resources\License as LicenseResourceMode
 use LicenseManagerForWooCommerce\Repositories\Resources\License as LicenseResourceRepository;
 use LicenseManagerForWooCommerce\Settings;
 use stdClass;
-use WC_Customer_Download;
-use WC_Data_Store;
 use WC_Order;
 use WC_Order_Item_Product;
 use WC_Product;
@@ -138,7 +136,6 @@ class Controller extends AbstractIntegrationController implements IntegrationCon
             )
         );
 
-        /** @var LicenseResourceModel $license */
         foreach ($licenses as $license) {
             $product = wc_get_product($license->getProductId());
 
@@ -204,7 +201,7 @@ class Controller extends AbstractIntegrationController implements IntegrationCon
             $expiresAt     = $gmtDate->add($dateExpiresAt)->format('Y-m-d H:i:s');
         }
 
-	    Order::instance()->updateOrderDownloadsExpiration( $expiresAt, $orderId );
+        lmfwc_update_order_downloads_expiration($expiresAt, $orderId);
 
         // Add the keys to the database table.
         foreach ($cleanLicenseKeys as $licenseKey) {
@@ -322,13 +319,13 @@ class Controller extends AbstractIntegrationController implements IntegrationCon
             );
 
             if ($license) {
-	            if ( $validFor ) {
-		            $date         = new DateTime();
-		            $dateInterval = new DateInterval( 'P' . $validFor . 'D' );
-		            $expiresAt    = $date->add( $dateInterval )->format( 'Y-m-d H:i:s' );
+                if ($validFor) {
+                    $date         = new DateTime();
+                    $dateInterval = new DateInterval('P' . $validFor . 'D');
+                    $expiresAt    = $date->add($dateInterval)->format('Y-m-d H:i:s');
 
-		            Order::instance()->updateOrderDownloadsExpiration( $expiresAt, $orderId );
-	            }
+                    lmfwc_update_order_downloads_expiration($expiresAt, $orderId);
+                }
 
                 $result['added']++;
             }
@@ -376,7 +373,6 @@ class Controller extends AbstractIntegrationController implements IntegrationCon
         }
 
         for ($i = 0; $i < $cleanAmount; $i++) {
-            /** @var LicenseResourceModel $license */
             $license   = $cleanLicenseKeys[$i];
             $validFor  = (int)$license->getValidFor();
             $expiresAt = $license->getExpiresAt();
@@ -436,7 +432,7 @@ class Controller extends AbstractIntegrationController implements IntegrationCon
                 // Order exists.
                 if ($order && $order instanceof WC_Order) {
                     $text = sprintf(
-                        /* translators: $1: order id, $2: customer name, $3: customer email */
+                    /* translators: $1: order id, $2: customer name, $3: customer email */
                         '#%1$s %2$s <%3$s>',
                         $order->get_id(),
                         $order->get_formatted_billing_full_name(),
@@ -458,7 +454,7 @@ class Controller extends AbstractIntegrationController implements IntegrationCon
                 // Product exists.
                 if ($product) {
                     $text = sprintf(
-                        /* translators: $1: order id, $2 customer name */
+                    /* translators: $1: order id, $2 customer name */
                         '(#%1$s) %2$s',
                         $product->get_id(),
                         $product->get_formatted_name()
@@ -487,7 +483,7 @@ class Controller extends AbstractIntegrationController implements IntegrationCon
                     $results[] = array(
                         'id' => $user->ID,
                         'text' => sprintf(
-                            /* translators: $1: user nicename, $2: user id, $3: user email */
+                        /* translators: $1: user nicename, $2: user id, $3: user email */
                             '%1$s (#%2$d - %3$s)',
                             $user->user_nicename,
                             $user->ID,
@@ -515,10 +511,9 @@ class Controller extends AbstractIntegrationController implements IntegrationCon
                     $more = false;
                 }
 
-                /** @var WC_Order $order */
                 foreach ($orders as $order) {
                     $text = sprintf(
-                    /* translators: $1: order id, $2 customer name, $3 customer email */
+                        /* translators: $1: order id, $2 customer name, $3 customer email */
                         '#%1$s %2$s <%3$s>',
                         $order->get_id(),
                         $order->get_formatted_billing_full_name(),

--- a/includes/integrations/woocommerce/Controller.php
+++ b/includes/integrations/woocommerce/Controller.php
@@ -15,6 +15,8 @@ use LicenseManagerForWooCommerce\Models\Resources\License as LicenseResourceMode
 use LicenseManagerForWooCommerce\Repositories\Resources\License as LicenseResourceRepository;
 use LicenseManagerForWooCommerce\Settings;
 use stdClass;
+use WC_Customer_Download;
+use WC_Data_Store;
 use WC_Order;
 use WC_Order_Item_Product;
 use WC_Product;
@@ -202,6 +204,8 @@ class Controller extends AbstractIntegrationController implements IntegrationCon
             $expiresAt     = $gmtDate->add($dateExpiresAt)->format('Y-m-d H:i:s');
         }
 
+	    Order::instance()->updateOrderDownloadsExpiration( $expiresAt, $orderId );
+
         // Add the keys to the database table.
         foreach ($cleanLicenseKeys as $licenseKey) {
             // Key exists, up the invalid keys count.
@@ -318,6 +322,14 @@ class Controller extends AbstractIntegrationController implements IntegrationCon
             );
 
             if ($license) {
+	            if ( $validFor ) {
+		            $date         = new DateTime();
+		            $dateInterval = new DateInterval( 'P' . $validFor . 'D' );
+		            $expiresAt    = $date->add( $dateInterval )->format( 'Y-m-d H:i:s' );
+
+		            Order::instance()->updateOrderDownloadsExpiration( $expiresAt, $orderId );
+	            }
+
                 $result['added']++;
             }
 

--- a/includes/integrations/woocommerce/MyAccount.php
+++ b/includes/integrations/woocommerce/MyAccount.php
@@ -29,9 +29,13 @@ class MyAccount
      */
     public function accountMenuItems($items)
     {
-        $items['view-license-keys'] = __('License keys', 'license-manager-for-woocommerce');
+        $custom_items = [
+            'view-license-keys' => __('License keys', 'license-manager-for-woocommerce')
+        ];
 
-        return $items;
+        $custom_items = array_slice( $items, 0, 2, true ) + $custom_items + array_slice( $items, 2, count( $items ), true );
+
+        return $custom_items;
     }
 
     /**

--- a/includes/integrations/woocommerce/MyAccount.php
+++ b/includes/integrations/woocommerce/MyAccount.php
@@ -29,13 +29,13 @@ class MyAccount
      */
     public function accountMenuItems($items)
     {
-        $custom_items = [
+        $customItems = array(
             'view-license-keys' => __('License keys', 'license-manager-for-woocommerce')
-        ];
+        );
 
-        $custom_items = array_slice( $items, 0, 2, true ) + $custom_items + array_slice( $items, 2, count( $items ), true );
+        $customItems = array_slice( $items, 0, 2, true ) + $customItems + array_slice( $items, 2, count( $items ), true );
 
-        return $custom_items;
+        return $customItems;
     }
 
     /**

--- a/includes/integrations/woocommerce/Order.php
+++ b/includes/integrations/woocommerce/Order.php
@@ -2,9 +2,6 @@
 
 namespace LicenseManagerForWooCommerce\Integrations\WooCommerce;
 
-use DateTime;
-use DateTimeZone;
-use LicenseManagerForWooCommerce\Abstracts\Singleton;
 use LicenseManagerForWooCommerce\Enums\LicenseStatus;
 use LicenseManagerForWooCommerce\Lists\LicensesList;
 use LicenseManagerForWooCommerce\Models\Resources\Generator as GeneratorResourceModel;
@@ -12,8 +9,6 @@ use LicenseManagerForWooCommerce\Models\Resources\License as LicenseResourceMode
 use LicenseManagerForWooCommerce\Repositories\Resources\Generator as GeneratorResourceRepository;
 use LicenseManagerForWooCommerce\Repositories\Resources\License as LicenseResourceRepository;
 use LicenseManagerForWooCommerce\Settings;
-use WC_Customer_Download;
-use WC_Data_Store;
 use WC_Order_Item_Product;
 use WC_Product_Simple;
 use function WC;
@@ -23,7 +18,7 @@ use WC_Product;
 
 defined('ABSPATH') || exit;
 
-class Order extends Singleton
+class Order
 {
     /**
      * OrderManager constructor.
@@ -396,39 +391,4 @@ class Order extends Singleton
 
         echo $html;
     }
-
-	/**
-	 * Updates the expiration of downloads in orders
-	 */
-	public function updateOrderDownloadsExpiration( $expiresAt, $orderId )
-	{
-		if ( ! empty( $expiresAt ) && ! empty( $orderId ) && Settings::get( 'lmfwc_download_expires' ) ) {
-			$dataStore           = WC_Data_Store::load( 'customer-download' );
-			$downloadPermissions = $dataStore->get_downloads(
-				[
-					'order_id' => $orderId
-				]
-			);
-
-			// Validate expiresAt is given in the right format (time check) - otherwise add current GMT time
-			if ( ! DateTime::createFromFormat( 'Y-m-d H:i:s', $expiresAt ) !== false ) {
-				$date  = new DateTime( $expiresAt, new DateTimeZone( 'GMT' ) );
-				$now   = new DateTime( 'now', new DateTimeZone( 'GMT' ) );
-				$today = new DateTime( date( 'Y-m-d' ), new DateTimeZone( 'GMT' ) );
-				$time  = $today->diff( $now );
-
-				$date->add( $time );
-
-				$expiresAt = $date->format( 'Y-m-d H:i:s' );
-			}
-
-			if ( $downloadPermissions && count( $downloadPermissions ) > 0 ) {
-				foreach ( $downloadPermissions as $download ) {
-					$download = new WC_Customer_Download( $download->get_id() );
-					$download->set_access_expires( $expiresAt );
-					$download->save();
-				}
-			}
-		}
-	}
 }

--- a/includes/integrations/woocommerce/Order.php
+++ b/includes/integrations/woocommerce/Order.php
@@ -2,6 +2,9 @@
 
 namespace LicenseManagerForWooCommerce\Integrations\WooCommerce;
 
+use DateTime;
+use DateTimeZone;
+use LicenseManagerForWooCommerce\Abstracts\Singleton;
 use LicenseManagerForWooCommerce\Enums\LicenseStatus;
 use LicenseManagerForWooCommerce\Lists\LicensesList;
 use LicenseManagerForWooCommerce\Models\Resources\Generator as GeneratorResourceModel;
@@ -9,6 +12,8 @@ use LicenseManagerForWooCommerce\Models\Resources\License as LicenseResourceMode
 use LicenseManagerForWooCommerce\Repositories\Resources\Generator as GeneratorResourceRepository;
 use LicenseManagerForWooCommerce\Repositories\Resources\License as LicenseResourceRepository;
 use LicenseManagerForWooCommerce\Settings;
+use WC_Customer_Download;
+use WC_Data_Store;
 use WC_Order_Item_Product;
 use WC_Product_Simple;
 use function WC;
@@ -18,7 +23,7 @@ use WC_Product;
 
 defined('ABSPATH') || exit;
 
-class Order
+class Order extends Singleton
 {
     /**
      * OrderManager constructor.
@@ -391,4 +396,39 @@ class Order
 
         echo $html;
     }
+
+	/**
+	 * Updates the expiration of downloads in orders
+	 */
+	public function updateOrderDownloadsExpiration( $expiresAt, $orderId )
+	{
+		if ( ! empty( $expiresAt ) && ! empty( $orderId ) && Settings::get( 'lmfwc_download_expires' ) ) {
+			$dataStore           = WC_Data_Store::load( 'customer-download' );
+			$downloadPermissions = $dataStore->get_downloads(
+				[
+					'order_id' => $orderId
+				]
+			);
+
+			// Validate expiresAt is given in the right format (time check) - otherwise add current GMT time
+			if ( ! DateTime::createFromFormat( 'Y-m-d H:i:s', $expiresAt ) !== false ) {
+				$date  = new DateTime( $expiresAt, new DateTimeZone( 'GMT' ) );
+				$now   = new DateTime( 'now', new DateTimeZone( 'GMT' ) );
+				$today = new DateTime( date( 'Y-m-d' ), new DateTimeZone( 'GMT' ) );
+				$time  = $today->diff( $now );
+
+				$date->add( $time );
+
+				$expiresAt = $date->format( 'Y-m-d H:i:s' );
+			}
+
+			if ( $downloadPermissions && count( $downloadPermissions ) > 0 ) {
+				foreach ( $downloadPermissions as $download ) {
+					$download = new WC_Customer_Download( $download->get_id() );
+					$download->set_access_expires( $expiresAt );
+					$download->save();
+				}
+			}
+		}
+	}
 }

--- a/includes/integrations/woocommerce/ProductData.php
+++ b/includes/integrations/woocommerce/ProductData.php
@@ -95,7 +95,6 @@ class ProductData
         $productChangelog   = get_post_meta( $post->ID, 'lmfwc_licensed_product_changelog', true );
 
         if ($generators) {
-            /** @var GeneratorResourceModel $generator */
             foreach ($generators as $generator) {
                 $generatorOptions[$generator->getId()] = sprintf(
                     '(#%d) %s',
@@ -191,59 +190,59 @@ class ProductData
 
         do_action('lmfwc_product_data_panel', $post);
 
-		if ( Settings::get( 'lmfwc_product_downloads' ) ) {
-			echo '</div><div class="options_group">';
+        if ( Settings::get( 'lmfwc_product_downloads' ) ) {
+            echo '</div><div class="options_group">';
 
-			woocommerce_wp_text_input(
-				array(
-					'id'          => 'lmfwc_licensed_product_version',
-					'label'       => esc_html__( 'Product version', 'license-manager-for-woocommerce' ),
-					'value'       => $productVersion,
-					'desc_tip'    => true,
-					'description' => esc_html__( 'Defines current version of the product.', 'license-manager-for-woocommerce' )
-				)
-			);
+            woocommerce_wp_text_input(
+                array(
+                    'id'          => 'lmfwc_licensed_product_version',
+                    'label'       => esc_html__( 'Product version', 'license-manager-for-woocommerce' ),
+                    'value'       => $productVersion,
+                    'desc_tip'    => true,
+                    'description' => esc_html__( 'Defines current version of the product.', 'license-manager-for-woocommerce' )
+                )
+            );
 
-			woocommerce_wp_text_input(
-				array(
-					'id'          => 'lmfwc_licensed_product_tested',
-					'label'       => esc_html__( 'Product tested', 'license-manager-for-woocommerce' ),
-					'value'       => $productTested,
-					'desc_tip'    => true,
-					'description' => esc_html__( 'The version of WordPress where the product has been tested up to.', 'license-manager-for-woocommerce' )
-				)
-			);
+            woocommerce_wp_text_input(
+                array(
+                    'id'          => 'lmfwc_licensed_product_tested',
+                    'label'       => esc_html__( 'Product tested', 'license-manager-for-woocommerce' ),
+                    'value'       => $productTested,
+                    'desc_tip'    => true,
+                    'description' => esc_html__( 'The version of WordPress where the product has been tested up to.', 'license-manager-for-woocommerce' )
+                )
+            );
 
-			woocommerce_wp_text_input(
-				array(
-					'id'          => 'lmfwc_licensed_product_requires',
-					'label'       => esc_html__( 'Product requires', 'license-manager-for-woocommerce' ),
-					'value'       => $productRequires,
-					'desc_tip'    => true,
-					'description' => esc_html__( 'The version of WordPress that the product requires.', 'license-manager-for-woocommerce' )
-				)
-			);
+            woocommerce_wp_text_input(
+                array(
+                    'id'          => 'lmfwc_licensed_product_requires',
+                    'label'       => esc_html__( 'Product requires', 'license-manager-for-woocommerce' ),
+                    'value'       => $productRequires,
+                    'desc_tip'    => true,
+                    'description' => esc_html__( 'The version of WordPress that the product requires.', 'license-manager-for-woocommerce' )
+                )
+            );
 
-			woocommerce_wp_text_input(
-				array(
-					'id'          => 'lmfwc_licensed_product_requires_php',
-					'label'       => esc_html__( 'Product requires PHP', 'license-manager-for-woocommerce' ),
-					'value'       => $productRequiresPhp,
-					'desc_tip'    => true,
-					'description' => esc_html__( 'The version of PHP that the product requires.', 'license-manager-for-woocommerce' )
-				)
-			);
-			?>
+            woocommerce_wp_text_input(
+                array(
+                    'id'          => 'lmfwc_licensed_product_requires_php',
+                    'label'       => esc_html__( 'Product requires PHP', 'license-manager-for-woocommerce' ),
+                    'value'       => $productRequiresPhp,
+                    'desc_tip'    => true,
+                    'description' => esc_html__( 'The version of PHP that the product requires.', 'license-manager-for-woocommerce' )
+                )
+            );
+            ?>
             <div class="form-field lmfwc_licensed_product_changelog">
                 <label><?= esc_html__( 'Product changelog', 'license-manager-for-woocommerce' ) ?></label>
-				<?php
-				wp_editor( $productChangelog, 'lmfwc_licensed_product_changelog', [ 'media_buttons' => false ] );
-				?>
+                <?php
+                wp_editor( $productChangelog, 'lmfwc_licensed_product_changelog', [ 'media_buttons' => false ] );
+                ?>
             </div>
-		<?php }
+        <?php }
 
-		echo '</div></div>';
-	}
+        echo '</div></div>';
+    }
 
     /**
      * Adds an icon to the new data tab.
@@ -331,33 +330,33 @@ class ProductData
             update_post_meta($postId, 'lmfwc_licensed_product_assigned_generator', 0);
         }
 
-		// Update the product version according to the field.
-		$productVersion = sanitize_text_field( wp_unslash( $_POST['lmfwc_licensed_product_version'] ) );
+        // Update the product version according to the field.
+        $productVersion = sanitize_text_field( wp_unslash( $_POST['lmfwc_licensed_product_version'] ) );
 
-		update_post_meta( $postId, 'lmfwc_licensed_product_version', $productVersion );
+        update_post_meta( $postId, 'lmfwc_licensed_product_version', $productVersion );
 
-		// Update the product WordPress version tested up to according to the field.
-		$productTested = sanitize_text_field( wp_unslash( $_POST['lmfwc_licensed_product_tested'] ) );
+        // Update the product WordPress version tested up to according to the field.
+        $productTested = sanitize_text_field( wp_unslash( $_POST['lmfwc_licensed_product_tested'] ) );
 
-		update_post_meta( $postId, 'lmfwc_licensed_product_tested', $productTested );
+        update_post_meta( $postId, 'lmfwc_licensed_product_tested', $productTested );
 
-		// Update the product required WordPress version according to the field.
-		$productRequires = sanitize_text_field( wp_unslash( $_POST['lmfwc_licensed_product_requires'] ) );
+        // Update the product required WordPress version according to the field.
+        $productRequires = sanitize_text_field( wp_unslash( $_POST['lmfwc_licensed_product_requires'] ) );
 
-		update_post_meta( $postId, 'lmfwc_licensed_product_requires', $productRequires );
+        update_post_meta( $postId, 'lmfwc_licensed_product_requires', $productRequires );
 
-		// Update the product required PHP version according to the field.
-		$productRequiresPhp = sanitize_text_field( wp_unslash( $_POST['lmfwc_licensed_product_requires_php'] ) );
+        // Update the product required PHP version according to the field.
+        $productRequiresPhp = sanitize_text_field( wp_unslash( $_POST['lmfwc_licensed_product_requires_php'] ) );
 
-		update_post_meta( $postId, 'lmfwc_licensed_product_requires_php', $productRequiresPhp );
+        update_post_meta( $postId, 'lmfwc_licensed_product_requires_php', $productRequiresPhp );
 
-		// Update the product changelog according to the field.
-		$productChangelog = wp_unslash( $_POST['lmfwc_licensed_product_changelog'] );
+        // Update the product changelog according to the field.
+        $productChangelog = wp_unslash( $_POST['lmfwc_licensed_product_changelog'] );
 
-		update_post_meta( $postId, 'lmfwc_licensed_product_changelog', $productChangelog );
+        update_post_meta( $postId, 'lmfwc_licensed_product_changelog', $productChangelog );
 
-		do_action( 'lmfwc_product_data_save_post', $postId );
-	}
+        do_action('lmfwc_product_data_save_post', $postId);
+    }
 
     /**
      * Adds the new product data fields to variable WooCommerce Products.
@@ -378,7 +377,6 @@ class ProductData
         $useStock          = get_post_meta($productId, 'lmfwc_licensed_product_use_stock',          true);
         $generatorOptions  = array('' => __('Please select a generator', 'license-manager-for-woocommerce'));
 
-        /** @var GeneratorResourceModel $generator */
         foreach ($generators as $generator) {
             $generatorOptions[$generator->getId()] = sprintf(
                 '(#%d) %s',

--- a/includes/settings/General.php
+++ b/includes/settings/General.php
@@ -104,21 +104,21 @@ class General
             'license_keys_section'
         );
 
-	    add_settings_field(
-		    'lmfwc_product_downloads',
-		    __('Product downloads', 'license-manager-for-woocommerce'),
-		    array($this, 'fieldProductDownloads'),
-		    'lmfwc_license_keys',
-		    'license_keys_section'
-	    );
+        add_settings_field(
+            'lmfwc_product_downloads',
+            __('Product downloads', 'license-manager-for-woocommerce'),
+            array($this, 'fieldProductDownloads'),
+            'lmfwc_license_keys',
+            'license_keys_section'
+        );
 
-	    add_settings_field(
-		    'lmfwc_download_expires',
-		    __('Download expires', 'license-manager-for-woocommerce'),
-		    array($this, 'fieldDownloadExpires'),
-		    'lmfwc_license_keys',
-		    'license_keys_section'
-	    );
+        add_settings_field(
+            'lmfwc_download_expires',
+            __('Download expires', 'license-manager-for-woocommerce'),
+            array($this, 'fieldDownloadExpires'),
+            'lmfwc_license_keys',
+            'license_keys_section'
+        );
 
         add_settings_field(
             'lmfwc_allow_duplicates',
@@ -615,18 +615,18 @@ class General
                 'method'     => 'POST',
                 'deprecated' => false,
             ),
-	          array(
-		            'id'         => '022',
-		            'name'       => 'v2/products/update/{license_key}',
-		            'method'     => 'GET',
-		            'deprecated' => false,
-	          ),
-	          array(
-		            'id'         => '023',
-		            'name'       => 'v2/products/download/latest/{license_key}',
-		            'method'     => 'GET',
-		            'deprecated' => false,
-	          ),
+            array(
+                'id'         => '022',
+                'name'       => 'v2/products/update/{license_key}',
+                'method'     => 'GET',
+                'deprecated' => false,
+            ),
+            array(
+                'id'         => '023',
+                'name'       => 'v2/products/download/latest/{license_key}',
+                'method'     => 'GET',
+                'deprecated' => false,
+            ),
         );
         $classList = array(
             'GET'  => 'text-success',

--- a/includes/settings/General.php
+++ b/includes/settings/General.php
@@ -104,6 +104,22 @@ class General
             'license_keys_section'
         );
 
+	    add_settings_field(
+		    'lmfwc_product_downloads',
+		    __('Product downloads', 'license-manager-for-woocommerce'),
+		    array($this, 'fieldProductDownloads'),
+		    'lmfwc_license_keys',
+		    'license_keys_section'
+	    );
+
+	    add_settings_field(
+		    'lmfwc_download_expires',
+		    __('Download expires', 'license-manager-for-woocommerce'),
+		    array($this, 'fieldDownloadExpires'),
+		    'lmfwc_license_keys',
+		    'license_keys_section'
+	    );
+
         add_settings_field(
             'lmfwc_allow_duplicates',
             __('Allow duplicates', 'license-manager-for-woocommerce'),
@@ -249,6 +265,70 @@ class General
         $html .= sprintf(
             '<p class="description">%s</p>',
             __('If this setting is off, you must manually send out all license keys for completed orders.', 'license-manager-for-woocommerce')
+        );
+        $html .= '</fieldset>';
+
+        echo $html;
+    }
+
+    /**
+     * Callback for the "lmfwc_product_downloads" field.
+     *
+     * @return void
+     */
+    public function fieldProductDownloads()
+    {
+        $field = 'lmfwc_product_downloads';
+        (array_key_exists($field, $this->settings)) ? $value = true : $value = false;
+
+        $html = '<fieldset>';
+        $html .= sprintf('<label for="%s">', $field);
+        $html .= sprintf(
+            '<input id="%s" type="checkbox" name="lmfwc_settings_general[%s]" value="1" %s/>',
+            $field,
+            $field,
+            checked(true, $value, false)
+        );
+        $html .= sprintf(
+            '<span>%s</span>',
+            __('Enable product download management for digital / virtual products e.g. WordPress themes, plugins & more.', 'license-manager-for-woocommerce')
+        );
+        $html .= '</label>';
+        $html .= sprintf(
+            '<p class="description">%s</p>',
+            __('If this setting is off, the download management for digital / virtual products is not available e.g. current version or changelog field in products.', 'license-manager-for-woocommerce')
+        );
+        $html .= '</fieldset>';
+
+        echo $html;
+    }
+
+    /**
+     * Callback for the "lmfwc_download_expires" field.
+     *
+     * @return void
+     */
+    public function fieldDownloadExpires()
+    {
+        $field = 'lmfwc_download_expires';
+        (array_key_exists($field, $this->settings)) ? $value = true : $value = false;
+
+        $html = '<fieldset>';
+        $html .= sprintf('<label for="%s">', $field);
+        $html .= sprintf(
+            '<input id="%s" type="checkbox" name="lmfwc_settings_general[%s]" value="1" %s/>',
+            $field,
+            $field,
+            checked(true, $value, false)
+        );
+        $html .= sprintf(
+            '<span>%s</span>',
+            __('Automatically set download expiration date in orders to the license expiration date.', 'license-manager-for-woocommerce')
+        );
+        $html .= '</label>';
+        $html .= sprintf(
+            '<p class="description">%s</p>',
+            __('If this setting is off, digital / virtual products can may still be downloaded when the license has expired.', 'license-manager-for-woocommerce')
         );
         $html .= '</fieldset>';
 
@@ -529,6 +609,18 @@ class General
                 'method'     => 'GET',
                 'deprecated' => false,
             ),
+	        array(
+		        'id'         => '021',
+		        'name'       => 'v2/products/update/{license_key}',
+		        'method'     => 'GET',
+		        'deprecated' => false,
+	        ),
+	        array(
+		        'id'         => '022',
+		        'name'       => 'v2/products/download/latest/{license_key}',
+		        'method'     => 'GET',
+		        'deprecated' => false,
+	        ),
         );
         $classList = array(
             'GET'  => 'text-success',


### PR DESCRIPTION
Hi Drazen,

as I wrote in my last PR, I'll now release the new product management feature to you which I developed in the last days because of my personal needs. In the following text I'll explain every change to you and add some examples you can use at your page like API descriptions and documentations. 

Since I've found no translation files, I think I need to translate the plugin a different way. I'm developing WP plugins for 3 years now but I've included all my language files directly into the plugin so please tell me the way you did this so that I can add my translation.

**Initial idea for the new feature**
Since I'm a WordPress developer I wanted to include a licensing system into my WP plugins I've developed. First I had the same idea for a plugin like yours but then I've found your plugin and it nearly fitted my needs. But some things were missing: 

- Automatic expirations of downloads in orders when the corresponding license expires
- A simple way to provide plugin updates to my customers
---
**Automatic expirations of downloads**
---
When a customer buys a digital product that contains downloadable content and he enabled the correct setting in the plugin, the file/files expiration date in an order get's set/changed in the following situations:

- License key generation via API and GUI using `valid_for` or `expires_at`
- License key changes via API and GUI using `valid_for` or `expires_at`

![image](https://user-images.githubusercontent.com/43766368/100937056-b8144c00-34f2-11eb-816a-5c5b75db2ed3.png)

The expiration get's only set when an order is set in the license. I've tested this multiple times without any issues. 

**Product updates via license**
---
When I want to sell a WordPress plugin license for example, I need to be able to provide plugin updates somehow because the plugin is not listed at WordPress directly. So I've created a new setting in the plugin that allows me to enable this feature. When it's enabled, I can see a new section in the WooCommerce product license tab:

![image](https://user-images.githubusercontent.com/43766368/100938587-3d006500-34f5-11eb-8d80-ce2af6f62a4f.png)

This allows me to define some important things about the plugin. The data will be used later in the API request. 
When the license selling checkbox for a product and the product download management checkbox is checked and a product is virtual and downloadable, your plugin only allows one file now in the downloadable files table since this must be a package like .zip for WordPress, otherwise a use of the WordPress update API would not be possible:

![image](https://user-images.githubusercontent.com/43766368/100939006-e5162e00-34f5-11eb-9d54-8f82a61a87df.png)

So for example when I add here the link to my plugin from my secure folder in WordPress and fill out every information, I'm good to go so let's talk about the two new endpoints.

**v2/products/update/{license_key}**
This endpoint can be called now to receive infos about the current installed plugin/product I've sold to my customer. So here is an example call for a license:

> https://www.xxxx.de/wp-json/lmfwc/v2/products/update/XXXX-XXXX-XXXX-XXXX

```
{
    "success": true,
    "data": {
        "license_key": "XXXX-XXXX-XXXX-XXXX",
        "url": "https://www.xxxx.de/shop/plugins/woomex/",
        "new_version": "1.1.0",
        "package": "https://xxxx.xxxx.de/wp-json/lmfwc/v2/products/download/latest/XXXX-XXXX-XXXX-XXXX?consumer_key=ck_............&consumer_secret=cs_..........",
        "tested": "5.5.3",
        "requires": "5.4.0",
        "requires_php": "7.0.0",
        "last_updated": "2020-12-01 23:29:57",
        "sections": {
            "changelog": "<p><strong>1.0.0</strong></p><ul><li>Initial release</li></ul>"
        }
    }
}
```
I can now pass this for example to the WordPress plugins API. WordPress automatically checks now if the installed plugin version is older than the one provided in the response. In the case this is true, WordPress shows an update for my plugin:

![image](https://user-images.githubusercontent.com/43766368/100939643-ec8a0700-34f6-11eb-8b1d-8351fc24686a.png)

When I now click the details button, I can now see the other details:

![image](https://user-images.githubusercontent.com/43766368/100939716-0c212f80-34f7-11eb-900a-b946e70b6db3.png)

But now we need to think about the updating part. Since you can provide WordPress an URL where the upgrader can download the new version from, I've passed another parameter package in the response which points to the second endpoint. The URL get's build together from the current auth params (GET or SERVER) and the license. When I press the update button now, WordPress automatically downloads the new package via the second new endpoint:

**v2/products/download/latest/{license_key}**
So when WordPress wants to download the update package, the endpoint first checks if the license exists and all that stuff you did for the other endpoints too (I've not included an expiration check since this needs to be done on the client side I think).

When everything is ok, the endpoint takes the first and only file from our product downloads table and returns it to WordPress where it will be unpacked and installed.

![image](https://user-images.githubusercontent.com/43766368/100940526-640c6600-34f8-11eb-91e4-7b4ab376c33c.png)

**Commit notices**
---
- Add new product management for e.g. WordPress plugins or themes sold via WooCommerce in combination with a license
- Re-write script.js using jQuery because plain JS was too complex and hacky for the new feature (I can explain you how it works in german if you need)
- Introduce order download expiration when a license key expires (updates when license updates in GUI & API)
- Introduce new endpoint for the products management (/products/update/ & /products/download/latest/)
- Extend Setup.php knowing the the controller
- Extend settings page (two new checkboxes for the new feature)
- Extend license tab in WooCommerce product showing the new input fields for product management
- Small UI fixes (Space between the two license buttons in an order)
![image](https://user-images.githubusercontent.com/43766368/100941053-48558f80-34f9-11eb-9641-310e39fd4260.png)


So I hope you like this new feature. I've tested it multiple times and I can confirm 100% that everything works. I'm also using this since 2 days without any issues. 

The script re-write was also tested 100% successful from my side. I hope you are not mad about the jQuery thing but it was my only solution for the files table changes because this would be a really complex code in plain JS.

If you have any questions, you can write me and I will help you out with coding. I'm working a lot with WooCommerce and WordPress coding so don't be shy to ask.